### PR TITLE
🔀 :: [#129] 게시글 - 게시글 목록 페이지 퍼블리싱

### DIFF
--- a/App/Resources/Icon/Icons.xcassets/Image.imageset/Contents.json
+++ b/App/Resources/Icon/Icons.xcassets/Image.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "filename" : "Frame 7407.svg",
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/Icon/Icons.xcassets/Image.imageset/Frame 7407.svg
+++ b/App/Resources/Icon/Icons.xcassets/Image.imageset/Frame 7407.svg
@@ -1,0 +1,5 @@
+<svg width="3" height="12" viewBox="0 0 3 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" width="2" height="2" rx="1" fill="#858585"/>
+<rect x="0.5" y="5" width="2" height="2" rx="1" fill="#858585"/>
+<rect x="0.5" y="10" width="2" height="2" rx="1" fill="#858585"/>
+</svg>

--- a/App/Resources/Icon/Icons.xcassets/vertical_ellipsis_fill.imageset/Contents.json
+++ b/App/Resources/Icon/Icons.xcassets/vertical_ellipsis_fill.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "filename" : "Frame 7407.svg",
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/Resources/Icon/Icons.xcassets/vertical_ellipsis_fill.imageset/Frame 7407.svg
+++ b/App/Resources/Icon/Icons.xcassets/vertical_ellipsis_fill.imageset/Frame 7407.svg
@@ -1,0 +1,5 @@
+<svg width="3" height="12" viewBox="0 0 3 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" width="2" height="2" rx="1" fill="#858585"/>
+<rect x="0.5" y="5" width="2" height="2" rx="1" fill="#858585"/>
+<rect x="0.5" y="10" width="2" height="2" rx="1" fill="#858585"/>
+</svg>

--- a/App/Sources/Feature/PostListFeature/Sources/Component/PostListRow.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/Component/PostListRow.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct PostListRow: View {
+    public let postId: String
+    public let title: String
+    public let modifedAt: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Spacer()
+
+            HStack {
+                BitgouelText(
+                    text: title,
+                    font: .text1
+                )
+
+                Spacer()
+
+                BitgouelAsset.Icons.verticalEllipsisFill.swiftUIImage
+            }
+
+            HStack(spacing: 0) {
+                BitgouelText(
+                    text: modifedAt,
+                    font: .caption
+                )
+
+                BitgouelText(
+                    text: "에 게시",
+                    font: .caption
+                )
+
+                Spacer()
+            }
+            .foregroundColor(.bitgouel(.greyscale(.g7)))
+
+            Spacer()
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct PostListView: View {
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                LazyVStack(spacing: 0) {
+                    ForEach(0...3, id: \.self) { index in
+                        PostListRow(
+                            postId: "index",
+                            title: "타이틀",
+                            modifedAt: "날짜"
+                        )
+                        
+                        Divider()
+                    }
+                }
+                
+                Spacer()
+            }
+                .padding(.horizontal, 28)
+                .navigationTitle("게시글 목록")
+                .toolbar {
+                    ToolbarItemGroup(placement: .navigationBarTrailing) {
+                        Button {} label: {
+                            BitgouelAsset.Icons.megaphone.swiftUIImage
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24, height: 24)
+                        }
+
+                        Button {} label: {
+                            BitgouelAsset.Icons.questionmark.swiftUIImage
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24, height: 24)
+                        }
+
+                        Button {} label: {
+                            Image(systemName: "plus")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 24, height: 24)
+                                .foregroundColor(.bitgouel(.greyscale(.g8)))
+                        }
+                    }
+                }
+
+            Spacer()
+        }
+    }
+}

--- a/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
@@ -3,50 +3,50 @@ import SwiftUI
 struct PostListView: View {
     var body: some View {
         NavigationView {
-            VStack(spacing: 0) {
-                LazyVStack(spacing: 0) {
-                    ForEach(0...3, id: \.self) { index in
-                        PostListRow(
-                            postId: "index",
-                            title: "타이틀",
-                            modifedAt: "날짜"
-                        )
-                        
-                        Divider()
+            ScrollView {
+                VStack(spacing: 0) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(0...3, id: \.self) { index in
+                            PostListRow(
+                                postId: "index",
+                                title: "타이틀",
+                                modifedAt: "날짜"
+                            )
+                            
+                            Divider()
+                        }
                     }
+                    
+                    Spacer()
                 }
-                
-                Spacer()
             }
-                .padding(.horizontal, 28)
-                .navigationTitle("게시글 목록")
-                .toolbar {
-                    ToolbarItemGroup(placement: .navigationBarTrailing) {
-                        Button {} label: {
-                            BitgouelAsset.Icons.megaphone.swiftUIImage
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 24, height: 24)
-                        }
-
-                        Button {} label: {
-                            BitgouelAsset.Icons.questionmark.swiftUIImage
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 24, height: 24)
-                        }
-
-                        Button {} label: {
-                            Image(systemName: "plus")
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 24, height: 24)
-                                .foregroundColor(.bitgouel(.greyscale(.g8)))
-                        }
+            .padding(.horizontal, 28)
+            .navigationTitle("게시글 목록")
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button {} label: {
+                        BitgouelAsset.Icons.megaphone.swiftUIImage
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                    }
+                    
+                    Button {} label: {
+                        BitgouelAsset.Icons.questionmark.swiftUIImage
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                    }
+                    
+                    Button {} label: {
+                        Image(systemName: "plus")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.bitgouel(.greyscale(.g8)))
                     }
                 }
-
-            Spacer()
+            }
         }
     }
 }


### PR DESCRIPTION
## 💡 개요
게시글 목록 페이지 퍼블리싱

## 📃 작업내용
<img width="300" alt="image" src="https://github.com/GSM-MSG/Bitgouel-iOS/assets/105629604/c48c0f51-80d4-47e0-a17f-b4f48808edf1">
게시글 목록 페이지를 퍼블리싱했어요

## 🎸 기타
기능 추가하면서 어드민, 학생에 따라 달라지는 Icon 등을 수정할게요.
