### PR TITLE
🔀 :: 게시글 - 게시글 상세보기 페이지 API 연결

### DIFF
--- a/App/Sources/Application/DI/Post/AppComponent+Post.swift
+++ b/App/Sources/Application/DI/Post/AppComponent+Post.swift
@@ -32,13 +32,13 @@ public extension AppComponent {
         }
     }
 
-    var updatePostUseCase: UpdatePostUseCase {
+    var updatePostUseCase: any UpdatePostUseCase {
         shared {
             UpdatePostUseCaseImpl(postRepository: postRepository)
         }
     }
 
-    var deletePostUseCase: DeletePostUseCase {
+    var deletePostUseCase: any DeletePostUseCase {
         shared {
             DeletePostUseCaseImpl(postRepository: postRepository)
         }

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -169,6 +169,12 @@ private class PostDetailDependencycf431278832ae8226535Provider: PostDetailDepend
     var editPostFactory: any EditPostFactory {
         return appComponent.editPostFactory
     }
+    var queryPostDetailUseCase: any QueryPostDetailUseCase {
+        return appComponent.queryPostDetailUseCase
+    }
+    var deletePostUseCase: any DeletePostUseCase {
+        return appComponent.deletePostUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -381,6 +387,8 @@ extension ClubDetailComponent: Registration {
 extension PostDetailComponent: Registration {
     public func registerItems() {
         keyPathToName[\PostDetailDependency.editPostFactory] = "editPostFactory-any EditPostFactory"
+        keyPathToName[\PostDetailDependency.queryPostDetailUseCase] = "queryPostDetailUseCase-any QueryPostDetailUseCase"
+        keyPathToName[\PostDetailDependency.deletePostUseCase] = "deletePostUseCase-any DeletePostUseCase"
     }
 }
 extension InquiryListComponent: Registration {
@@ -459,8 +467,8 @@ extension AppComponent: Registration {
         localTable["writePostUseCase-any WritePostUseCase"] = { [unowned self] in self.writePostUseCase as Any }
         localTable["queryPostListUseCase-any QueryPostListUseCase"] = { [unowned self] in self.queryPostListUseCase as Any }
         localTable["queryPostDetailUseCase-any QueryPostDetailUseCase"] = { [unowned self] in self.queryPostDetailUseCase as Any }
-        localTable["updatePostUseCase-UpdatePostUseCase"] = { [unowned self] in self.updatePostUseCase as Any }
-        localTable["deletePostUseCase-DeletePostUseCase"] = { [unowned self] in self.deletePostUseCase as Any }
+        localTable["updatePostUseCase-any UpdatePostUseCase"] = { [unowned self] in self.updatePostUseCase as Any }
+        localTable["deletePostUseCase-any DeletePostUseCase"] = { [unowned self] in self.deletePostUseCase as Any }
         localTable["localAuthDataSource-any LocalAuthDataSource"] = { [unowned self] in self.localAuthDataSource as Any }
         localTable["remoteAuthDataSource-any RemoteAuthDataSource"] = { [unowned self] in self.remoteAuthDataSource as Any }
         localTable["authRepository-any AuthRepository"] = { [unowned self] in self.authRepository as Any }

--- a/App/Sources/DesignSystem/View/DetailView.swift
+++ b/App/Sources/DesignSystem/View/DetailView.swift
@@ -65,11 +65,15 @@ struct DetailView: View {
                 spacing: 4
             ) {
                 ForEach(links, id: \.self) { link in
-                    Link(destination: URL(string: link)!) {
-                        BitgouelText(
-                            text: "\(link)",
-                            font: .caption
-                        )
+                    if let url = URL(string: link) {
+                        Link(destination: url, label: {
+                            BitgouelText(
+                                text: "\(url)",
+                                font: .caption
+                            )
+                        })
+                    } else {
+                        EmptyView()
                     }
                 }
             }

--- a/App/Sources/Feature/InputPostFeature/Source/InputPostView.swift
+++ b/App/Sources/Feature/InputPostFeature/Source/InputPostView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct InputPostView: View {
+    @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: InputPostViewModel
     
     private let postDetailSettingFactory: any PostDetailSettingFactory
@@ -24,6 +25,7 @@ struct InputPostView: View {
                     },
                     finalButtonAction: {
                         viewModel.addPost()
+                        dismiss()
                     },
                     title: Binding(
                         get: { viewModel.postTitle },

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailComponent.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailComponent.swift
@@ -4,6 +4,7 @@ import Service
 
 public protocol PostDetailDependency: Dependency {
     var editPostFactory: any EditPostFactory { get }
+    var queryPostDetailUseCase: any QueryPostDetailUseCase { get }
 }
 
 public final class PostDetailComponent: Component<PostDetailDependency>, PostDetailFactory {
@@ -12,7 +13,8 @@ public final class PostDetailComponent: Component<PostDetailDependency>, PostDet
     ) -> some View {
         PostDetailView(
             viewModel: .init(
-                postID: postID
+                postID: postID,
+                queryPostDetailUseCase: dependency.queryPostDetailUseCase
             ),
             editPostFactory: dependency.editPostFactory
         )

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailComponent.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailComponent.swift
@@ -5,6 +5,7 @@ import Service
 public protocol PostDetailDependency: Dependency {
     var editPostFactory: any EditPostFactory { get }
     var queryPostDetailUseCase: any QueryPostDetailUseCase { get }
+    var deletePostUseCase: any DeletePostUseCase { get }
 }
 
 public final class PostDetailComponent: Component<PostDetailDependency>, PostDetailFactory {
@@ -14,7 +15,8 @@ public final class PostDetailComponent: Component<PostDetailDependency>, PostDet
         PostDetailView(
             viewModel: .init(
                 postID: postID,
-                queryPostDetailUseCase: dependency.queryPostDetailUseCase
+                queryPostDetailUseCase: dependency.queryPostDetailUseCase,
+                deletePostUseCase: dependency.deletePostUseCase
             ),
             editPostFactory: dependency.editPostFactory
         )

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailView.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailView.swift
@@ -14,28 +14,31 @@ struct PostDetailView: View {
     }
     
     var body: some View {
-        DetailView(
-            title: viewModel.postTitle,
-            content: viewModel.postContent,
-            links: viewModel.postRelatedLink,
-            deleteAction: {
-            },
-            editAction: {
-                viewModel.editAction()
-            },
-            isDelete: Binding(
-                get: { viewModel.isPostDelete },
-                set: { value in viewModel.isPostDelete = value }
+            DetailView(
+                title: viewModel.postDetail?.title ?? "",
+                content: viewModel.postDetail?.content ?? "",
+                links: viewModel.postDetail?.links ?? [""],
+                deleteAction: {
+                },
+                editAction: {
+                    viewModel.editAction()
+                },
+                isDelete: Binding(
+                    get: { viewModel.isPostDelete },
+                    set: { value in viewModel.isPostDelete = value }
+                )
             )
-        )
-        .navigate(
-            to: editPostFactory.makeView(postID: viewModel.postID).eraseToAnyView(),
-            when: Binding(
-                get: { viewModel.isPresentedEditView },
-                set: { _ in
-                    viewModel.isPresentedEditView = false
-                }
+            .onAppear {
+                viewModel.onAppear()
+            }
+            .navigate(
+                to: editPostFactory.makeView(postID: viewModel.postID).eraseToAnyView(),
+                when: Binding(
+                    get: { viewModel.isPresentedEditView },
+                    set: { _ in
+                        viewModel.isPresentedEditView = false
+                    }
+                )
             )
-        )
     }
 }

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailView.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct PostDetailView: View {
+    @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: PostDetailViewModel
     
     private let editPostFactory: any EditPostFactory
@@ -19,6 +20,8 @@ struct PostDetailView: View {
                 content: viewModel.postDetail?.content ?? "",
                 links: viewModel.postDetail?.links ?? [""],
                 deleteAction: {
+                    viewModel.postDelete()
+                    dismiss()
                 },
                 editAction: {
                     viewModel.editAction()

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailViewModel.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailViewModel.swift
@@ -8,13 +8,16 @@ final class PostDetailViewModel: BaseViewModel {
     @Published var isPresentedEditView: Bool = false
 
     private let queryPostDetailUseCase: any QueryPostDetailUseCase
+    private let deletePostUseCase: any DeletePostUseCase
 
     init(
         postID: String,
-        queryPostDetailUseCase: any QueryPostDetailUseCase
+        queryPostDetailUseCase: any QueryPostDetailUseCase,
+        deletePostUseCase: any DeletePostUseCase
     ) {
         self.postID = postID
         self.queryPostDetailUseCase = queryPostDetailUseCase
+        self.deletePostUseCase = deletePostUseCase
     }
     
     func editAction() {
@@ -26,6 +29,16 @@ final class PostDetailViewModel: BaseViewModel {
         Task {
             do {
                 postDetail = try await queryPostDetailUseCase(postID: postID)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
+    func postDelete() {
+        Task {
+            do {
+                try await deletePostUseCase(postID: postID)
             } catch {
                 print(error.localizedDescription)
             }

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailViewModel.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailViewModel.swift
@@ -39,6 +39,7 @@ final class PostDetailViewModel: BaseViewModel {
         Task {
             do {
                 try await deletePostUseCase(postID: postID)
+                print("게시글 삭제 완료")
             } catch {
                 print(error.localizedDescription)
             }

--- a/App/Sources/Feature/PostDetailFeature/Source/PostDetailViewModel.swift
+++ b/App/Sources/Feature/PostDetailFeature/Source/PostDetailViewModel.swift
@@ -1,18 +1,34 @@
 import Foundation
+import Service
 
 final class PostDetailViewModel: BaseViewModel {
-    @Published var postTitle: String = ""
-    @Published var postContent: String = ""
-    @Published var postRelatedLink: [String] = []
+    @Published var postDetail: PostDetailEntity?
     @Published var isPostDelete: Bool = false
     @Published var postID: String = ""
     @Published var isPresentedEditView: Bool = false
-    
-    init(postID: String) {
+
+    private let queryPostDetailUseCase: any QueryPostDetailUseCase
+
+    init(
+        postID: String,
+        queryPostDetailUseCase: any QueryPostDetailUseCase
+    ) {
         self.postID = postID
+        self.queryPostDetailUseCase = queryPostDetailUseCase
     }
     
     func editAction() {
         isPresentedEditView = true
+    }
+    
+    @MainActor
+    func onAppear() {
+        Task {
+            do {
+                postDetail = try await queryPostDetailUseCase(postID: postID)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
     }
 }

--- a/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
@@ -34,9 +34,9 @@ struct PostListView: View {
                                     title: item.title,
                                     modifiedAt: item.modifiedAt.toDateCustomFormat(format: "yyyy-MM-dd'T'HH:mm:ss.SSS"),
                                     isPresented: Binding(get: {
-                                        viewModel.isPresentedAleterBottomSheet
+                                        viewModel.isPresentedPostDetailView
                                     }, set: { isPresented in
-                                        viewModel.isPresentedAleterBottomSheet = isPresented
+                                        viewModel.isPresentedPostDetailView = isPresented
                                     })
                                 )
                                 .onTapGesture {

--- a/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
@@ -83,7 +83,6 @@ struct PostListView: View {
                     )
                 )
                 .padding(.horizontal, 28)
-                .alterBottomSheet(isShowing: $viewModel.isPresentedAleterBottomSheet)
                 .navigationTitle("게시글 목록")
                 .toolbar {
                     ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -118,6 +117,9 @@ struct PostListView: View {
                         }
                     }
                 }
+            }
+            .refreshable {
+                viewModel.onAppear()
             }
         }
     }

--- a/App/Sources/Feature/PostListFeature/Sources/PostListViewModel.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListViewModel.swift
@@ -13,7 +13,6 @@ final class PostListViewModel: BaseViewModel {
 
     @Published var _postContent: PostContentEntity?
     @Published var authority: UserAuthorityType = .user
-    @Published var isPresentedAleterBottomSheet: Bool = false
     @Published var isPresentedNoticeListView: Bool = false
     @Published var isPresentedInquiryView: Bool = false
     @Published var isPresentedInputPostView: Bool = false

--- a/Service/Sources/Domain/PostDomain/API/PostAPI.swift
+++ b/Service/Sources/Domain/PostDomain/API/PostAPI.swift
@@ -24,7 +24,7 @@ extension PostAPI: BitgouelAPI {
         case let .queryPostDetail(postID),
              let .updatePost(postID, _),
              let .deletePost(postID):
-            return "\(postID)"
+            return "/\(postID)"
         }
     }
 


### PR DESCRIPTION
## 💡 개요
게시글 상세보기 페이지에 API를 연결했어요.

## 📃 작업내용
- queryPostDetailUseCase를 사용해 게시글 상세데이터를 가져왔어요.
- deletePostUseCase를 사용해 게시글 삭제하는 기능을 추가했어요.
- refreshable로 목록을 다시 불러오는 기능을 추가했어요.

## 🔀 변경사항
DetailView에서 Link를 가져오는 부분에서 오류가 있어서 해결했어요.
PostListView에서 BottomSheet가 필요하지 않게 되어서 삭제했어요.
