### PR TITLE
CI 스크립트 verbose 삭제

### DIFF
--- a/.github/workflows/bitgouel-ios-ci.yml
+++ b/.github/workflows/bitgouel-ios-ci.yml
@@ -63,7 +63,7 @@ jobs:
       run: tuist fetch
 
     - name: Test with tuist
-      run: TUIST_CI=1 tuist test --verbose
+      run: TUIST_CI=1 tuist test
 
     - name: Bitgouel iOS CI Discord Notification
       uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
## 💡 개요
verbose 옵션으로 인해 상세하게나오지만 오히려 Test 실패시 이유를 찾지 못하게 됩니다.

## 📃 작업내용
verbose 옵션을 삭제 하였습니다.
