### PR TITLE
🔀 :: [#197] 공지사항 - 공지사항 세부설정 페이지 추가

### DIFF
--- a/App/Sources/Application/DI/AppComponent.swift
+++ b/App/Sources/Application/DI/AppComponent.swift
@@ -106,4 +106,8 @@ public extension AppComponent {
     var inputNoticeFactory: any InputNoticeFactory {
         InputNoticeComponent(parent: self)
     }
+    
+    var noticeDetailSettingFactory: any NoticeDetailSettingFactory {
+        NoticeDetailSettingComponent(parent: self)
+    }
 }

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -100,6 +100,9 @@ private class NoticeListDependency0e93eb53be8626c408e4Provider: NoticeListDepend
     var queryPostListUseCase: any QueryPostListUseCase {
         return appComponent.queryPostListUseCase
     }
+    var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase {
+        return appComponent.loadUserAuthorityUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -151,7 +154,21 @@ private class ActivityDetailSettingDependency0b98c5f90168b920a8b8Provider: Activ
 private func factoryfd595280dea209e217b9e3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
     return ActivityDetailSettingDependency0b98c5f90168b920a8b8Provider()
 }
+private class NoticeDetailSettingDependencye2c86b5d9ab8fbf629c4Provider: NoticeDetailSettingDependency {
+
+
+    init() {
+
+    }
+}
+/// ^->AppComponent->NoticeDetailSettingComponent
+private func factory24d19202afbef2333be9e3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return NoticeDetailSettingDependencye2c86b5d9ab8fbf629c4Provider()
+}
 private class InputNoticeDependency7b594803ad882c7e25c9Provider: InputNoticeDependency {
+    var noticeDetailSettingFactory: any NoticeDetailSettingFactory {
+        return appComponent.noticeDetailSettingFactory
+    }
     var queryPostDetailUseCase: any QueryPostDetailUseCase {
         return appComponent.queryPostDetailUseCase
     }
@@ -494,6 +511,7 @@ extension NoticeListComponent: Registration {
         keyPathToName[\NoticeListDependency.noticeDetailFactory] = "noticeDetailFactory-any NoticeDetailFactory"
         keyPathToName[\NoticeListDependency.inputNoticeFactory] = "inputNoticeFactory-any InputNoticeFactory"
         keyPathToName[\NoticeListDependency.queryPostListUseCase] = "queryPostListUseCase-any QueryPostListUseCase"
+        keyPathToName[\NoticeListDependency.loadUserAuthorityUseCase] = "loadUserAuthorityUseCase-any LoadUserAuthorityUseCase"
     }
 }
 extension SignUpComponent: Registration {
@@ -512,8 +530,14 @@ extension ActivityDetailSettingComponent: Registration {
 
     }
 }
+extension NoticeDetailSettingComponent: Registration {
+    public func registerItems() {
+
+    }
+}
 extension InputNoticeComponent: Registration {
     public func registerItems() {
+        keyPathToName[\InputNoticeDependency.noticeDetailSettingFactory] = "noticeDetailSettingFactory-any NoticeDetailSettingFactory"
         keyPathToName[\InputNoticeDependency.queryPostDetailUseCase] = "queryPostDetailUseCase-any QueryPostDetailUseCase"
         keyPathToName[\InputNoticeDependency.writePostUseCase] = "writePostUseCase-any WritePostUseCase"
         keyPathToName[\InputNoticeDependency.updatePostUseCase] = "updatePostUseCase-any UpdatePostUseCase"
@@ -712,6 +736,7 @@ extension AppComponent: Registration {
         localTable["certificationListFactory-any CertificationListFactory"] = { [unowned self] in self.certificationListFactory as Any }
         localTable["inputCertificationFactory-any InputCertificationFactory"] = { [unowned self] in self.inputCertificationFactory as Any }
         localTable["inputNoticeFactory-any InputNoticeFactory"] = { [unowned self] in self.inputNoticeFactory as Any }
+        localTable["noticeDetailSettingFactory-any NoticeDetailSettingFactory"] = { [unowned self] in self.noticeDetailSettingFactory as Any }
         localTable["remoteCertificationDataSource-any RemoteCertificationDataSource"] = { [unowned self] in self.remoteCertificationDataSource as Any }
         localTable["certificationRepository-any CertificationRepository"] = { [unowned self] in self.certificationRepository as Any }
         localTable["queryCertificationListByTeacherUseCase-any QueryCertificationListByTeacherUseCase"] = { [unowned self] in self.queryCertificationListByTeacherUseCase as Any }
@@ -743,6 +768,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->NoticeListComponent", factorye14e687c08985bdffcd0f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->SignUpComponent", factory306e8ce5cfdf41304709f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->ActivityDetailSettingComponent", factoryfd595280dea209e217b9e3b0c44298fc1c149afb)
+    registerProviderFactory("^->AppComponent->NoticeDetailSettingComponent", factory24d19202afbef2333be9e3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->InputNoticeComponent", factory4545df5fcd42aaf8ed60f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->RootComponent", factory264bfc4d4cb6b0629b40f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->PostListComponent", factory0c89e2bbcc02dbcac018f47b58f8f304c97af4d5)

--- a/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeComponent.swift
+++ b/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeComponent.swift
@@ -3,6 +3,7 @@ import Service
 import SwiftUI
 
 public protocol InputNoticeDependency: Dependency {
+    var noticeDetailSettingFactory: any NoticeDetailSettingFactory { get }
     var queryPostDetailUseCase: any QueryPostDetailUseCase { get }
     var writePostUseCase: any WritePostUseCase { get }
     var updatePostUseCase: any UpdatePostUseCase { get }
@@ -20,7 +21,8 @@ public final class InputNoticeComponent: Component<InputNoticeDependency>, Input
                 queryPostDetailUseCase: dependency.queryPostDetailUseCase,
                 writePostUseCase: dependency.writePostUseCase,
                 updatePostUseCase: dependency.updatePostUseCase
-            )
+            ),
+            noticeDetailSettingFactory: dependency.noticeDetailSettingFactory
         )
     }
 }

--- a/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeView.swift
+++ b/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeView.swift
@@ -3,17 +3,23 @@ import SwiftUI
 struct InputNoticeView: View {
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: InputNoticeViewModel
-
-    init(viewModel: InputNoticeViewModel) {
+    
+    private let noticeDetailSettingFactory: any NoticeDetailSettingFactory
+    
+    init(
+        viewModel: InputNoticeViewModel,
+        noticeDetailSettingFactory: any NoticeDetailSettingFactory
+    ) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        self.noticeDetailSettingFactory = noticeDetailSettingFactory
     }
-
+    
     var body: some View {
         InputFormView(
             epic: "공지사항",
             state: viewModel.state,
             settingButtonAction: {
-                viewModel.updateIsPresentedNoticeSettingView(isPresented: true)
+                viewModel.updateIsPresentedNoticeSettingAppend(isPresented: true)
             },
             finalButtonAction: {
                 viewModel.applyButtonDidTap()
@@ -31,6 +37,21 @@ struct InputNoticeView: View {
         .onAppear {
             if viewModel.state == "수정" {
                 viewModel.onAppear()
+            }
+        }
+        .fullScreenCover(
+            isPresented: Binding(
+                get: { viewModel.isPresentedNoticeDetailSettingAppend },
+                set: { isPresented in
+                    viewModel.updateIsPresentedNoticeSettingAppend(isPresented: isPresented)
+                }
+            )
+        ) {
+            DeferView {
+                noticeDetailSettingFactory.makeView(noticeLinks: viewModel.noticeLinks) {
+                    links in
+                    viewModel.updateNoticeLinks(links: links)
+                }.eraseToAnyView()
             }
         }
     }

--- a/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeViewModel.swift
+++ b/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeViewModel.swift
@@ -5,7 +5,7 @@ final class InputNoticeViewModel: BaseViewModel {
     @Published var noticeTitle: String = ""
     @Published var noticeContent: String = ""
     @Published var noticeLinks: [String] = []
-    @Published var isPresentedNoticeSettingView: Bool = false
+    @Published var isPresentedNoticeDetailSettingAppend: Bool = false
     var state: String = ""
     var noticeID: String = ""
 
@@ -39,8 +39,8 @@ final class InputNoticeViewModel: BaseViewModel {
         noticeLinks = links
     }
 
-    func updateIsPresentedNoticeSettingView(isPresented: Bool) {
-        isPresentedNoticeSettingView = isPresented
+    func updateIsPresentedNoticeSettingAppend(isPresented: Bool) {
+        isPresentedNoticeDetailSettingAppend = isPresented
     }
 
     @MainActor

--- a/App/Sources/Feature/NoticeDetailSettingFeature/Interface/NoticeDetailSettingFactory.swift
+++ b/App/Sources/Feature/NoticeDetailSettingFeature/Interface/NoticeDetailSettingFactory.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import Service
+
+public protocol NoticeDetailSettingFactory {
+    associatedtype SomeView: View
+    func makeView(
+        noticeLinks: [String],
+        completion: @escaping ([String]) -> Void
+    ) -> SomeView
+}

--- a/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingComponent.swift
+++ b/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingComponent.swift
@@ -1,0 +1,19 @@
+import NeedleFoundation
+import SwiftUI
+import Service
+
+public protocol NoticeDetailSettingDependency: Dependency {}
+
+public final class NoticeDetailSettingComponent: Component<NoticeDetailSettingDependency>, NoticeDetailSettingFactory {
+    public func makeView(
+        noticeLinks: [String],
+        completion: @escaping ([String]) -> Void
+    ) -> some View {
+        NoticeDetailSettingView(
+            viewModel: .init(
+                noticeLinks: noticeLinks,
+                completion: completion
+            )
+        )
+    }
+}

--- a/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingView.swift
+++ b/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct NoticeDetailSettingView: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject var viewModel: NoticeDetailSettingViewModel
+    
+    init(viewModel: NoticeDetailSettingViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                LinkDetailSettingView(
+                    links: viewModel.noticeLinks,
+                    link: viewModel.link,
+                    dismiss: dismiss
+                ) { links in
+                    viewModel.applyButtonDidTap(link: links)
+                }
+            }
+            .padding(.horizontal, 28)
+            .navigationTitle("공지사항 세부 설정")
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        BitgouelAsset.Icons.cancel.swiftUIImage
+                    }
+                }
+            }
+        }
+    }
+}

--- a/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingViewModel.swift
+++ b/App/Sources/Feature/NoticeDetailSettingFeature/Source/NoticeDetailSettingViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Service
+
+final class NoticeDetailSettingViewModel: BaseViewModel {
+    @Published var noticeLinks: [String] = []
+    @Published var link: String = ""
+    
+    private var completion: ([String]) -> Void
+    
+    init(
+        noticeLinks: [String],
+        completion: @escaping ([String]) -> Void
+    ) {
+        self.noticeLinks = noticeLinks
+        self.completion = completion
+    }
+    
+    func applyButtonDidTap(link: [String]) {
+        noticeLinks = link
+        completion(noticeLinks)
+    }
+}

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListComponent.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListComponent.swift
@@ -7,13 +7,15 @@ public protocol NoticeListDependency: Dependency {
     var noticeDetailFactory: any NoticeDetailFactory { get }
     var inputNoticeFactory: any InputNoticeFactory { get }
     var queryPostListUseCase: any QueryPostListUseCase { get }
+    var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase { get }
 }
 
 public final class NoticeListComponent: Component<NoticeListDependency>, NoticeListFactory {
     public func makeview() -> some View {
         NoticeListView(
             viewModel: .init(
-                queryPostListUseCase: dependency.queryPostListUseCase
+                queryPostListUseCase: dependency.queryPostListUseCase,
+                loadUserAuthorityUseCase: dependency.loadUserAuthorityUseCase
             ),
             inquiryListFactory: dependency.inquiryListFactory,
             noticeDetailFactory: dependency.noticeDetailFactory,

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
@@ -63,10 +63,12 @@ struct NoticeListView: View {
                         BitgouelAsset.Icons.questionmark.swiftUIImage
                     }
 
-                    Button {
-                        viewModel.updateIsPresentedInputNoticeView(isPresented: true)
-                    } label: {
-                        BitgouelAsset.Icons.add.swiftUIImage
+                    if viewModel.authority == .admin {
+                        Button {
+                            viewModel.updateIsPresentedInputNoticeView(isPresented: true)
+                        } label: {
+                            BitgouelAsset.Icons.add.swiftUIImage
+                        }
                     }
                 }
             }

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListViewModel.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListViewModel.swift
@@ -15,11 +15,17 @@ final class NoticeListViewModel: BaseViewModel {
 
     @Published var _noticeContent: PostContentEntity?
     @Published var noticeID: String = ""
+    var authority: UserAuthorityType = .user
 
     private let queryPostListUseCase: any QueryPostListUseCase
+    private let loadUserAuthorityUseCase: any LoadUserAuthorityUseCase
 
-    init(queryPostListUseCase: any QueryPostListUseCase) {
+    init(
+        queryPostListUseCase: any QueryPostListUseCase,
+        loadUserAuthorityUseCase: any LoadUserAuthorityUseCase
+    ) {
         self.queryPostListUseCase = queryPostListUseCase
+        self.loadUserAuthorityUseCase = loadUserAuthorityUseCase
     }
 
     func updateIsPresentedInquiryListView(isPresented: Bool) {
@@ -36,6 +42,8 @@ final class NoticeListViewModel: BaseViewModel {
 
     @MainActor
     func onAppear() {
+        authority = loadUserAuthorityUseCase()
+
         Task {
             do {
                 noticeContent = try await queryPostListUseCase(postType: .notice)


### PR DESCRIPTION
## 💡 개요
공지사항 세부설정 페이지를 추가했어요.

## 📃 작업내용

https://github.com/GSM-MSG/Bitgouel-iOS/assets/105629604/db696dd0-c22f-4469-8c15-87211e4088f9

## 🔀 변경사항
NoticeListView에서 admin만 공지사항을 추가할 수 있도록 변경했어요.
