### PR TITLE
🔀 :: [#225] 학생활동 상세보기 페이지 리팩토링

### DIFF
--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ActivityDetailView: View {
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: ActivityDetailViewModel
-    
+
     private let inputActivityFactory: any InputActivityFactory
     init(
         viewModel: ActivityDetailViewModel,
@@ -13,29 +13,29 @@ struct ActivityDetailView: View {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.inputActivityFactory = inputActivityFactory
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
             if let activityDetail = viewModel.activityDetail {
                 VStack(alignment: .leading) {
                     HStack {
                         Spacer()
-                        
+
                         HStack(spacing: 0) {
                             Text(activityDetail.modifiedAt.toStringCustomFormat(format: "yyyy년M월dd일HH:mm"))
-                            
+
                             Text("에 수정됨")
                         }
                         .foregroundColor(.bitgouel(.greyscale(.g7)))
                     }
                     .font(.bitgouel(.caption))
-                    
+
                     BitgouelText(
                         text: activityDetail.title,
                         font: .text1
                     )
                     .padding(.top, 4)
-                    
+
                     HStack {
                         BitgouelText(
                             text: activityDetail.activityDate.toStringCustomFormat(format: "yyyy.M.d"),
@@ -45,29 +45,29 @@ struct ActivityDetailView: View {
                             text: "활동",
                             font: .text3
                         )
-                        
+
                         Spacer()
-                        
+
                         HStack(spacing: 0) {
                             BitgouelText(
                                 text: "\(activityDetail.credit)",
                                 font: .text3
                             )
                             .padding(.leading, 4)
-                            
+
                             BitgouelText(text: "점 수여", font: .text3)
                         }
                     }
                     .foregroundColor(.bitgouel(.greyscale(.g4)))
                     .padding(.top, 4)
                 }
-                
+
                 ScrollView(showsIndicators: false) {
                     Text(activityDetail.content)
                         .multilineTextAlignment(.leading)
                 }
                 .padding(.top, 24)
-                
+
                 if viewModel.authority == .student {
                     popupButtonByWriter()
                 }
@@ -101,7 +101,7 @@ struct ActivityDetailView: View {
             ]
         )
     }
-    
+
     @ViewBuilder
     func popupButtonByWriter() -> some View {
         HStack {
@@ -112,9 +112,9 @@ struct ActivityDetailView: View {
                     viewModel.updateIsPresentedInputActivityView(isPresented: true)
                 }
             )
-            
+
             Spacer()
-            
+
             CTAButton(
                 text: "활동 삭제",
                 style: .error,

--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct ActivityDetailView: View {
     @StateObject var viewModel: ActivityDetailViewModel
-
+    
     private let inputActivityFactory: any InputActivityFactory
     init(
         viewModel: ActivityDetailViewModel,
@@ -15,60 +15,63 @@ struct ActivityDetailView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading) {
-                HStack {
-                    Spacer()
-                    
-                    HStack(spacing: 0) {
-                        Text(viewModel.activityDetail?.modifiedAt.toStringCustomFormat(format: "yyyy년M월dd일HH:mm") ?? "")
+            if let activityDetail = viewModel.activityDetail {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Spacer()
                         
-                        Text("에 수정됨")
+                        HStack(spacing: 0) {
+                            Text(activityDetail.modifiedAt.toStringCustomFormat(format: "yyyy년M월dd일HH:mm"))
+                            
+                            Text("에 수정됨")
+                        }
+                        .foregroundColor(.bitgouel(.greyscale(.g7)))
                     }
-                    .foregroundColor(.bitgouel(.greyscale(.g7)))
-                }
-                .font(.bitgouel(.caption))
-                
-                BitgouelText(
-                    text: viewModel.activityDetail?.title ?? "",
-                    font: .text1
-                )
-                .padding(.top, 4)
-                
-                HStack {
-                    BitgouelText(
-                        text: viewModel.activityDetail?.activityDate ?? "",
-                        font: .text3
-                    )
-                    BitgouelText(
-                        text: "활동",
-                        font: .text3
-                    )
+                    .font(.bitgouel(.caption))
                     
-                    Spacer()
+                    BitgouelText(
+                        text: activityDetail.title,
+                        font: .text1
+                    )
+                    .padding(.top, 4)
                     
-                    HStack(spacing: 0) {
-                        BitgouelText(text: "학점", font: .text3)
-                        
+                    HStack {
                         BitgouelText(
-                            text: "\(viewModel.activityDetail?.credit ?? 0)",
+                            text: activityDetail.activityDate,
                             font: .text3
                         )
-                        .padding(.leading, 4)
+                        BitgouelText(
+                            text: "활동",
+                            font: .text3
+                        )
                         
-                        BitgouelText(text: "점 부여", font: .text3)
+                        Spacer()
+                        
+                        HStack(spacing: 0) {
+                            BitgouelText(text: "학점", font: .text3)
+                            
+                            BitgouelText(
+                                text: "\(activityDetail.credit)",
+                                font: .text3
+                            )
+                            .padding(.leading, 4)
+                            
+                            BitgouelText(text: "점 부여", font: .text3)
+                        }
                     }
+                    .foregroundColor(.bitgouel(.greyscale(.g4)))
+                    .padding(.top, 4)
                 }
-                .foregroundColor(.bitgouel(.greyscale(.g4)))
-                .padding(.top, 4)
-            }
-            
-            ScrollView {
-                Text(viewModel.activityDetail?.content ?? "")
-            }
-            .padding(.top, 24)
-            
-            if viewModel.authority == .student {
-                popupButtonByWriter()
+                
+                ScrollView(showsIndicators: false) {
+                    Text(activityDetail.content)
+                        .multilineTextAlignment(.leading)
+                }
+                .padding(.top, 24)
+                
+                if viewModel.authority == .student {
+                    popupButtonByWriter()
+                }
             }
         }
         .onAppear {
@@ -90,7 +93,7 @@ struct ActivityDetailView: View {
             isShowing: $viewModel.isDelete,
             alertActions: [
                 .init(text: "취소", style: .cancel) {
-                    viewModel.isDelete = false
+                    viewModel.updateIsDelete(state: false)
                 },
                 .init(text: "삭제", style: .error) {
                     viewModel.deleteActivity()
@@ -116,7 +119,7 @@ struct ActivityDetailView: View {
                 text: "활동 삭제",
                 style: .error,
                 action: {
-                    viewModel.isDelete = true
+                    viewModel.updateIsDelete(state: true)
                 }
             )
         }

--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
@@ -2,6 +2,7 @@ import Service
 import SwiftUI
 
 struct ActivityDetailView: View {
+    @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: ActivityDetailViewModel
     
     private let inputActivityFactory: any InputActivityFactory
@@ -37,7 +38,7 @@ struct ActivityDetailView: View {
                     
                     HStack {
                         BitgouelText(
-                            text: activityDetail.activityDate,
+                            text: activityDetail.activityDate.toStringCustomFormat(format: "yyyy.M.d"),
                             font: .text3
                         )
                         BitgouelText(
@@ -48,15 +49,13 @@ struct ActivityDetailView: View {
                         Spacer()
                         
                         HStack(spacing: 0) {
-                            BitgouelText(text: "학점", font: .text3)
-                            
                             BitgouelText(
                                 text: "\(activityDetail.credit)",
                                 font: .text3
                             )
                             .padding(.leading, 4)
                             
-                            BitgouelText(text: "점 부여", font: .text3)
+                            BitgouelText(text: "점 수여", font: .text3)
                         }
                     }
                     .foregroundColor(.bitgouel(.greyscale(.g4)))
@@ -97,6 +96,7 @@ struct ActivityDetailView: View {
                 },
                 .init(text: "삭제", style: .error) {
                     viewModel.deleteActivity()
+                    dismiss()
                 }
             ]
         )

--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailViewModel.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailViewModel.swift
@@ -26,6 +26,10 @@ final class ActivityDetailViewModel: BaseViewModel {
         self.deleteActivityUseCase = deleteActivityUseCase
     }
 
+    func updateIsDelete(state: Bool) {
+        isDelete = state
+    }
+    
     func updateIsPresentedInputActivityView(isPresented: Bool) {
         isPresentedInputActivityView = isPresented
     }

--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailViewModel.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailViewModel.swift
@@ -29,7 +29,7 @@ final class ActivityDetailViewModel: BaseViewModel {
     func updateIsDelete(state: Bool) {
         isDelete = state
     }
-    
+
     func updateIsPresentedInputActivityView(isPresented: Bool) {
         isPresentedInputActivityView = isPresented
     }

--- a/App/Sources/Feature/ActivityDetailSettingFeature/Sources/ActivityDetailSettingView.swift
+++ b/App/Sources/Feature/ActivityDetailSettingFeature/Sources/ActivityDetailSettingView.swift
@@ -88,14 +88,13 @@ struct ActivityDetailSettingView: View {
                     viewModel.applyButtonDidTap()
                     dismiss()
                 }
-
-                .bitgouelBottomSheet(
-                    isShowing: $viewModel.isPresentedCreditSheet
-                ) {
-                    setCreditBottomSheet()
-                }
             }
             .padding(.horizontal, 28)
+            .bitgouelBottomSheet(
+                isShowing: $viewModel.isPresentedCreditSheet
+            ) {
+                setCreditBottomSheet()
+            }
             .navigationTitle("활동 세부 설정")
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -142,5 +141,6 @@ struct ActivityDetailSettingView: View {
             }
             .padding(.vertical, 24)
         }
+        .padding(.horizontal, 28)
     }
 }

--- a/App/Sources/Feature/InputActivityFeature/Source/InputActivityViewModel.swift
+++ b/App/Sources/Feature/InputActivityFeature/Source/InputActivityViewModel.swift
@@ -42,7 +42,7 @@ final class InputActivityViewModel: BaseViewModel {
         activityTitle = entity.title
         activityText = entity.content
         activityCredit = entity.credit
-        activityDate = entity.activityDate.toDateCustomFormat(format: "yyyy-MM-dd")
+        activityDate = entity.activityDate
     }
 
     @MainActor

--- a/Service/Sources/Domain/ActivityDomain/DTO/Response/ActivityDetailResponseDTO.swift
+++ b/Service/Sources/Domain/ActivityDomain/DTO/Response/ActivityDetailResponseDTO.swift
@@ -41,7 +41,7 @@ extension ActivityDetailResponseDTO {
             title: title,
             content: content,
             credit: credit,
-            activityDate: activityDate,
+            activityDate: activityDate.toDateCustomFormat(format: "yyyy-MM-dd"),
             modifiedAt: modifiedAt.toDateCustomFormat(format: "yyyy-MM-dd'T'HH:mm:ss.SSS")
         )
     }

--- a/Service/Sources/Domain/ActivityDomain/Entity/ActivityDetailEntity.swift
+++ b/Service/Sources/Domain/ActivityDomain/Entity/ActivityDetailEntity.swift
@@ -5,7 +5,7 @@ public struct ActivityDetailEntity: Equatable {
     public let title: String
     public let content: String
     public let credit: Int
-    public let activityDate: String
+    public let activityDate: Date
     public let modifiedAt: Date
 
     public init(
@@ -13,7 +13,7 @@ public struct ActivityDetailEntity: Equatable {
         title: String,
         content: String,
         credit: Int,
-        activityDate: String,
+        activityDate: Date,
         modifiedAt: Date
     ) {
         self.activityID = activityID

--- a/Service/Sources/Testing/UseCase/FetchActivityDetailUseCaseStub.swift
+++ b/Service/Sources/Testing/UseCase/FetchActivityDetailUseCaseStub.swift
@@ -26,7 +26,7 @@ public final class FetchActivityDetailUseCaseStub: FetchActivityDetailUseCase {
             청춘은 인생의 황금 시대(黃金時代)다. 우리는 이 황금 시대의 가치를 충분히 발휘하기 위하여, 이 황금 시대를 영원히 붙잡아 두기 위하여, 힘차게 노래하며 힘차게 약동하자!
             """,
             credit: 2,
-            activityDate: "2023.10.31",
+            activityDate: Date(),
             modifiedAt: Date()
         )
     }


### PR DESCRIPTION
## 💡 개요
학생활동 상세보기 페이지를 리팩토링했어요.

## 📃 작업내용
디자인이랑 현재 코드랑 다른 부분이 있어서 수정했어요.

## 🔀 변경사항
ActivityDetailEntity에 있는 activityDate의 Type을 Date로 변경해서 2024-03-04 처럼 보여져서 디자인과 다르던 활동날짜를 2024.3.4로 보여지도록 변경했어요.
