### PR TITLE
🔀 :: [#235] 자격증 수정 버튼 클릭 시 페이지 이동 추가

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -201,19 +201,6 @@ private class MyPageDependency48d84b530313b3ee40feProvider: MyPageDependency {
 private func factory0f6f456ebf157d02dfb3e3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
     return MyPageDependency48d84b530313b3ee40feProvider()
 }
-private class WriteInquiryAnswerDependencyeba82c0423abdd3e1acfProvider: WriteInquiryAnswerDependency {
-    var replyInquiryUseCase: any ReplyInquiryUseCase {
-        return appComponent.replyInquiryUseCase
-    }
-    private let appComponent: AppComponent
-    init(appComponent: AppComponent) {
-        self.appComponent = appComponent
-    }
-}
-/// ^->AppComponent->WriteInquiryAnswerComponent
-private func factory3d4cadf14cd9a3336981f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
-    return WriteInquiryAnswerDependencyeba82c0423abdd3e1acfProvider(appComponent: parent1(component) as! AppComponent)
-}
 private class InquiryDetailDependencyf68d260d1f6dc07aaedbProvider: InquiryDetailDependency {
     var inputInquiryFactory: any InputInquiryFactory {
         return appComponent.inputInquiryFactory
@@ -381,6 +368,19 @@ private class CertificationListDependency809c1dfea1282552ea2dProvider: Certifica
 /// ^->AppComponent->CertificationListComponent
 private func factoryc231b853779286e489fbf47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
     return CertificationListDependency809c1dfea1282552ea2dProvider(appComponent: parent1(component) as! AppComponent)
+}
+private class WriteInquiryAnswerDependencyeba82c0423abdd3e1acfProvider: WriteInquiryAnswerDependency {
+    var replyInquiryUseCase: any ReplyInquiryUseCase {
+        return appComponent.replyInquiryUseCase
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
+    }
+}
+/// ^->AppComponent->WriteInquiryAnswerComponent
+private func factory3d4cadf14cd9a3336981f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return WriteInquiryAnswerDependencyeba82c0423abdd3e1acfProvider(appComponent: parent1(component) as! AppComponent)
 }
 private class PostDetailDependencycf431278832ae8226535Provider: PostDetailDependency {
     var editPostFactory: any EditPostFactory {
@@ -673,11 +673,6 @@ extension MyPageComponent: Registration {
 
     }
 }
-extension WriteInquiryAnswerComponent: Registration {
-    public func registerItems() {
-        keyPathToName[\WriteInquiryAnswerDependency.replyInquiryUseCase] = "replyInquiryUseCase-any ReplyInquiryUseCase"
-    }
-}
 extension InquiryDetailComponent: Registration {
     public func registerItems() {
         keyPathToName[\InquiryDetailDependency.inputInquiryFactory] = "inputInquiryFactory-any InputInquiryFactory"
@@ -738,6 +733,11 @@ extension CertificationListComponent: Registration {
         keyPathToName[\CertificationListDependency.queryCertificationListByStudentUseCase] = "queryCertificationListByStudentUseCase-any QueryCertificationListByStudentUseCase"
         keyPathToName[\CertificationListDependency.queryCertificationListByTeacherUseCase] = "queryCertificationListByTeacherUseCase-any QueryCertificationListByTeacherUseCase"
         keyPathToName[\CertificationListDependency.inputCertificationFactory] = "inputCertificationFactory-any InputCertificationFactory"
+    }
+}
+extension WriteInquiryAnswerComponent: Registration {
+    public func registerItems() {
+        keyPathToName[\WriteInquiryAnswerDependency.replyInquiryUseCase] = "replyInquiryUseCase-any ReplyInquiryUseCase"
     }
 }
 extension PostDetailComponent: Registration {
@@ -959,7 +959,6 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->MainTabComponent", factory1ab5a747ddf21e1393f9f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->NoticeDetailSettingComponent", factory24d19202afbef2333be9e3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->MyPageComponent", factory0f6f456ebf157d02dfb3e3b0c44298fc1c149afb)
-    registerProviderFactory("^->AppComponent->WriteInquiryAnswerComponent", factory3d4cadf14cd9a3336981f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InquiryDetailComponent", factory2d6736bd037393a86ae3f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InputNoticeComponent", factory4545df5fcd42aaf8ed60f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->MainComponent", factoryc9274e46e78e70f29c54e3b0c44298fc1c149afb)
@@ -968,6 +967,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->ClubDetailComponent", factory1559652f8e80cfa88d06f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->SuccessSignUpComponent", factorybf219b153b668170161df47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->CertificationListComponent", factoryc231b853779286e489fbf47b58f8f304c97af4d5)
+    registerProviderFactory("^->AppComponent->WriteInquiryAnswerComponent", factory3d4cadf14cd9a3336981f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->PostDetailComponent", factorybc555a73df3767a26999f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InquiryListComponent", factorydd7e28250a180554c7a0f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->EditPostComponent", factoryf55a9d7f6c1ed8d0f0aef47b58f8f304c97af4d5)

--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
@@ -15,8 +15,8 @@ struct ActivityDetailView: View {
     }
     
     var body: some View {
-        VStack(spacing: 24) {
-            VStack(spacing: 0) {
+        VStack(spacing: 0) {
+            VStack(spacing: 24) {
                 if let activityDetail = viewModel.activityDetail {
                     VStack(alignment: .leading) {
                         HStack {

--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
@@ -14,7 +14,7 @@ struct ActivityDetailView: View {
     }
     
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 24) {
             VStack(alignment: .leading) {
                 HStack {
                     Spacer()
@@ -62,10 +62,12 @@ struct ActivityDetailView: View {
                 .padding(.top, 4)
             }
             
+            Divider()
+            
             ScrollView {
                 Text(viewModel.activityDetail?.content ?? "")
+                    .multilineTextAlignment(.leading)
             }
-            .padding(.top, 24)
             
             if viewModel.authority == .student {
                 popupButtonByWriter()

--- a/App/Sources/Feature/CertificationListFeature/Source/CertificationListView.swift
+++ b/App/Sources/Feature/CertificationListFeature/Source/CertificationListView.swift
@@ -97,7 +97,13 @@ struct CertificationListView: View {
                             title: certification.name,
                             acquisitionDate: certification.acquisitionDate
                         ) {
-                            print("edit")
+                            viewModel.updateEpic(epic: "수정")
+                            viewModel.selectedCertification(
+                                certificationID: certification.certificationID,
+                                certificationName: certification.name,
+                                acquisitionDate: certification.acquisitionDate
+                            )
+                            viewModel.updateIsPresentedInputCertificationView(isPresented: true)
                         }
 
                         Divider()
@@ -125,7 +131,9 @@ struct CertificationListView: View {
             DeferView {
                 inputCertificationFactory.makeView(
                     epic: viewModel.selectedEpic,
-                    certificationID: viewModel.certificationID
+                    certificationID: viewModel.selectedCertificationID,
+                    certificationName: viewModel.selectedCertificationName, 
+                    acquisitionDate: viewModel.selectedAcquisitionDate
                 ).eraseToAnyView()
             }
         }

--- a/App/Sources/Feature/CertificationListFeature/Source/CertificationListViewModel.swift
+++ b/App/Sources/Feature/CertificationListFeature/Source/CertificationListViewModel.swift
@@ -9,7 +9,9 @@ final class CertificationListViewModel: BaseViewModel {
     @Published var authority: UserAuthorityType = .user
     @Published var isPresentedInputCertificationView: Bool = false
     @Published var selectedEpic: String = ""
-    @Published var certificationID: String = ""
+    @Published var selectedCertificationID: String = ""
+    @Published var selectedCertificationName: String = ""
+    @Published var selectedAcquisitionDate = Date()
     var studentID: String = ""
     var clubID: Int = 0
 
@@ -44,6 +46,12 @@ final class CertificationListViewModel: BaseViewModel {
 
     func updateEpic(epic: String) {
         selectedEpic = epic
+    }
+
+    func selectedCertification(certificationID: String, certificationName: String, acquisitionDate: String) {
+        selectedCertificationID = certificationID
+        selectedCertificationName = certificationName
+        selectedAcquisitionDate = acquisitionDate.toDateCustomFormat(format: "yyyy-M-d")
     }
 
     func onAppear() {

--- a/App/Sources/Feature/InputCertificationFeature/Interface/InputCertificationFactory.swift
+++ b/App/Sources/Feature/InputCertificationFeature/Interface/InputCertificationFactory.swift
@@ -4,6 +4,8 @@ public protocol InputCertificationFactory {
     associatedtype SomeView: View
     func makeView(
         epic: String,
-        certificationID: String
+        certificationID: String,
+        certificationName: String,
+        acquisitionDate: Date
     ) -> SomeView
 }

--- a/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationComponent.swift
+++ b/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationComponent.swift
@@ -10,14 +10,18 @@ public protocol InputCertificationDependency: Dependency {
 public final class InputCertificationComponent: Component<InputCertificationDependency>, InputCertificationFactory {
     public func makeView(
         epic: String,
-        certificationID: String
+        certificationID: String,
+        certificationName: String,
+        acquisitionDate: Date
     ) -> some View {
         InputCertificationView(
             viewModel: .init(
                 inputCertificationUseCase: dependency.inputCertificationUseCase,
                 updateCertificationUseCase: dependency.updateCertificationUseCase,
                 epic: epic,
-                certificationID: certificationID
+                certificationID: certificationID,
+                certificationName: certificationName,
+                acquisitionDate: acquisitionDate
             )
         )
     }

--- a/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationViewModel.swift
+++ b/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationViewModel.swift
@@ -3,7 +3,7 @@ import Service
 
 final class InputCertificationViewModel: BaseViewModel {
     @Published var certificationName: String = ""
-    @Published var acquisitionDate = Date()
+    @Published var acquisitionDate: Date
     var epic: String = ""
     var certificationID: String = ""
 
@@ -14,12 +14,16 @@ final class InputCertificationViewModel: BaseViewModel {
         inputCertificationUseCase: any InputCertificationUseCase,
         updateCertificationUseCase: any UpdateCertificationUseCase,
         epic: String,
-        certificationID: String
+        certificationID: String,
+        certificationName: String,
+        acquisitionDate: Date
     ) {
         self.inputCertificationUseCase = inputCertificationUseCase
         self.updateCertificationUseCase = updateCertificationUseCase
         self.epic = epic
         self.certificationID = certificationID
+        self.certificationName = certificationName
+        self.acquisitionDate = acquisitionDate
     }
 
     func updateDate(date: Date) {


### PR DESCRIPTION
## 💡 개요
깜빡하고 추가 안 한 자격증 수정 페이지 이동을 추가했어요.

## 📃 작업내용

https://github.com/GSM-MSG/Bitgouel-iOS/assets/105629604/bd0fadf6-f2a5-4644-8836-bbb20b2e4268

자격증 리스트 Row에서 수정 버튼을 누르면 수정 페이지 모달이 뜨게 추가했어요.

## 🔀 변경사항
수정 페이지에 필요한 certificationName, acquisitionDate, certificationID를 리스트 페이지에서 보내도록 변경했어요.