### PR TITLE
🔀 :: [#246] 어드민 - 사용자 명단 페이지 API 연결

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -210,6 +210,9 @@ private class MyPageDependency48d84b530313b3ee40feProvider: MyPageDependency {
     var changePasswordFactory: any ChangePasswordFactory {
         return appComponent.changePasswordFactory
     }
+    var adminUserListFactory: any AdminUserListFactory {
+        return appComponent.adminUserListFactory
+    }
     var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase {
         return appComponent.loadUserAuthorityUseCase
     }
@@ -752,6 +755,7 @@ extension NoticeDetailSettingComponent: Registration {
 extension MyPageComponent: Registration {
     public func registerItems() {
         keyPathToName[\MyPageDependency.changePasswordFactory] = "changePasswordFactory-any ChangePasswordFactory"
+        keyPathToName[\MyPageDependency.adminUserListFactory] = "adminUserListFactory-any AdminUserListFactory"
         keyPathToName[\MyPageDependency.loadUserAuthorityUseCase] = "loadUserAuthorityUseCase-any LoadUserAuthorityUseCase"
         keyPathToName[\MyPageDependency.fetchMyInfoUseCase] = "fetchMyInfoUseCase-any FetchMyInfoUseCase"
         keyPathToName[\MyPageDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -94,6 +94,9 @@ private class AdminUserListDependency44bf9c85ea93b1b98debProvider: AdminUserList
     var adminWithdrawUserListFactory: any AdminWithdrawUserListFactory {
         return appComponent.adminWithdrawUserListFactory
     }
+    var fetchUserListUseCase: any FetchUserListUseCase {
+        return appComponent.fetchUserListUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -711,6 +714,7 @@ extension AdminUserListComponent: Registration {
     public func registerItems() {
         keyPathToName[\AdminUserListDependency.adminRequestUserSignupFactory] = "adminRequestUserSignupFactory-any AdminRequestUserSignupFactory"
         keyPathToName[\AdminUserListDependency.adminWithdrawUserListFactory] = "adminWithdrawUserListFactory-any AdminWithdrawUserListFactory"
+        keyPathToName[\AdminUserListDependency.fetchUserListUseCase] = "fetchUserListUseCase-any FetchUserListUseCase"
     }
 }
 extension NoticeListComponent: Registration {

--- a/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListComponent.swift
+++ b/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListComponent.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public protocol AdminUserListDependency: Dependency {
     var adminRequestUserSignupFactory: any AdminRequestUserSignupFactory { get }
     var adminWithdrawUserListFactory: any AdminWithdrawUserListFactory { get }
+    var fetchUserListUseCase: any FetchUserListUseCase { get }
 }
 
 public final class AdminUserListComponent: Component<AdminUserListDependency>, AdminUserListFactory {
@@ -12,8 +13,7 @@ public final class AdminUserListComponent: Component<AdminUserListDependency>, A
     public func makeView() -> some View {
         AdminUserListView(
             viewModel: .init(
-                adminWithdrawUserListFactory: dependency.adminWithdrawUserListFactory,
-                adminRequestUserSignupFactory: dependency.adminRequestUserSignupFactory
+                fetchUserListUseCase: dependency.fetchUserListUseCase
             ),
             adminWithdrawUserListFactory: dependency.adminWithdrawUserListFactory,
             adminRequestUserSignupFactory: dependency.adminRequestUserSignupFactory

--- a/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListView.swift
+++ b/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListView.swift
@@ -23,7 +23,10 @@ struct AdminUserListView: View {
                 HStack(spacing: 10) {
                     UserNameSearchTextField(
                         text: $viewModel.keyword
-                    ) {}
+                    )
+                    .onChange(of: viewModel.keyword) { _ in
+                        viewModel.onAppear()
+                    }
                     
                     BitgouelAsset.Icons.filterStroke.swiftUIImage
                         .padding(.horizontal, 10)

--- a/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListView.swift
+++ b/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListView.swift
@@ -22,7 +22,7 @@ struct AdminUserListView: View {
             VStack(spacing: 0) {
                 HStack(spacing: 10) {
                     UserNameSearchTextField(
-                        text: $viewModel.searchName
+                        text: $viewModel.keyword
                     ) {}
                     
                     BitgouelAsset.Icons.filterStroke.swiftUIImage
@@ -38,76 +38,46 @@ struct AdminUserListView: View {
                 }
                 .padding(.top, 24)
                 
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(0..<1) { _ in
-                        HStack(spacing: 8) {
-                            BitgouelText(
-                                text: "홍길동",
-                                font: .text1
-                            )
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(viewModel.userList, id: \.userID) { userInfo in
+                            HStack(spacing: 8) {
+                                BitgouelText(
+                                    text: userInfo.name,
+                                    font: .text1
+                                )
+                                
+                                BitgouelText(
+                                    text: userInfo.authority.display(),
+                                    font: .text1
+                                )
+                                .foregroundColor(.bitgouel(.greyscale(.g6)))
+                            }
                             
-                            BitgouelText(
-                                text: "학생",
-                                font: .text1
-                            )
-                            .foregroundColor(.bitgouel(.greyscale(.g6)))
+                            Divider()
+                                .frame(height: 1)
+                                .padding(.vertical, 14)
                         }
-                        
-                        Divider()
-                            .frame(height: 1)
-                            .padding(.vertical, 14)
                     }
                 }
                 .padding(.top, 24)
-                
-                Spacer()
             }
             .padding(.horizontal, 28)
-            .navigationTitle("사용자 명단")
-            .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button {
-                        viewModel.isNavigateRequestSignUpDidTap = true
-                    } label: {
-                        BitgouelAsset.Icons.addFill.swiftUIImage
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 24, height: 24)
-                    }
-                    
-                    Button {
-                        viewModel.isNavigateWithdrawListDidTap = true
-                    } label: {
-                        BitgouelAsset.Icons.minusFill.swiftUIImage
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 24, height: 24)
-                    }
-                }
-            }
-            .navigate(
-                to: adminRequestUserSignupFactory.makeView().eraseToAnyView(),
-                when: Binding(
-                    get: { viewModel.isNavigateRequestSignUpDidTap }, set: { _ in viewModel.requestSignUpPageDismissed() }
-                )
-            )
-            .navigate(
-                to: adminWithdrawUserListFactory.makeView().eraseToAnyView(),
-                when: Binding(
-                    get: { viewModel.isNavigateWithdrawListDidTap },
-                    set: { _ in viewModel.withdrawListPageDismissed() }
-                )
-            )
+
             ZStack(alignment: .center) {
                 if viewModel.isPresentedUserTypeFilter {
                     Color.black.opacity(0.4)
                         .edgesIgnoringSafeArea(.all)
+                        .onTapGesture {
+                            viewModel.isPresentedUserTypeFilter = false
+                        }
                     
                     UserTypeFilterPopup(
                         userAuthorityType: viewModel.userAuthorityType,
                         selectedAuthority: viewModel.selectedAuthority
                     ) { authority in
                         viewModel.selectedAuthority = authority
+                        viewModel.onAppear()
                     } cancel: { cancel in
                         viewModel.updateIsPresentedUserTypeFilter(isPresented: cancel)
                     }
@@ -115,6 +85,45 @@ struct AdminUserListView: View {
                     
                 }
             }
+            .zIndex(1)
         }
+        .navigationTitle("사용자 명단")
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button {
+                    viewModel.isNavigateRequestSignUpDidTap = true
+                } label: {
+                    BitgouelAsset.Icons.addFill.swiftUIImage
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 24, height: 24)
+                }
+                
+                Button {
+                    viewModel.isNavigateWithdrawListDidTap = true
+                } label: {
+                    BitgouelAsset.Icons.minusFill.swiftUIImage
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 24, height: 24)
+                }
+            }
+        }
+        .navigate(
+            to: adminRequestUserSignupFactory.makeView().eraseToAnyView(),
+            when: Binding(
+                get: { viewModel.isNavigateRequestSignUpDidTap }, set: { _ in viewModel.requestSignUpPageDismissed() }
+            )
+        )
+        .navigate(
+            to: adminWithdrawUserListFactory.makeView().eraseToAnyView(),
+            when: Binding(
+                get: { viewModel.isNavigateWithdrawListDidTap },
+                set: { _ in viewModel.withdrawListPageDismissed() }
+            )
+        )
     }
 }

--- a/App/Sources/Feature/MyPageFeature/Source/MyPageComponent.swift
+++ b/App/Sources/Feature/MyPageFeature/Source/MyPageComponent.swift
@@ -4,6 +4,7 @@ import Service
 
 public protocol MyPageDependency: Dependency {
     var changePasswordFactory: any ChangePasswordFactory { get }
+    var adminUserListFactory: any AdminUserListFactory { get }
     var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase { get }
     var fetchMyInfoUseCase: any FetchMyInfoUseCase { get }
     var logoutUseCase: any LogoutUseCase { get }
@@ -19,7 +20,8 @@ public final class MyPageComponent: Component<MyPageDependency>, MyPageFactory {
                 logoutUseCase: dependency.logoutUseCase,
                 withdrawalUseCase: dependency.withdrawalUseCase
             ),
-            changePasswordFactory: dependency.changePasswordFactory
+            changePasswordFactory: dependency.changePasswordFactory,
+            adminUserListFactory: dependency.adminUserListFactory
         )
     }
 }

--- a/App/Sources/Feature/MyPageFeature/Source/MyPageView.swift
+++ b/App/Sources/Feature/MyPageFeature/Source/MyPageView.swift
@@ -6,13 +6,16 @@ struct MyPageView: View {
     @Environment(\.tabbarHidden) var tabbarHidden
 
     private let changePasswordFactory: any ChangePasswordFactory
+    private let adminUserListFactory: any AdminUserListFactory
 
     init(
         viewModel: MyPageViewModel,
-        changePasswordFactory: any ChangePasswordFactory
+        changePasswordFactory: any ChangePasswordFactory,
+        adminUserListFactory: any AdminUserListFactory
     ) {
         _viewModel = StateObject(wrappedValue: viewModel)
         self.changePasswordFactory = changePasswordFactory
+        self.adminUserListFactory = adminUserListFactory
     }
     
     var body: some View {
@@ -156,6 +159,15 @@ struct MyPageView: View {
             .onChange(of: viewModel.isPresentedChangePasswordView) { newValue in
                 tabbarHidden.wrappedValue = newValue
             }
+            .navigate(
+                to: adminUserListFactory.makeView().eraseToAnyView(),
+                when: Binding(
+                    get: { viewModel.isPresentedAdminUserListView },
+                    set: { isPresented in
+                        viewModel.updateIsPresentedAdminUserListView(isPresented: isPresented)
+                    }
+                )
+            )
             .bitgouelAlert(
                 title: "회원 탈퇴하시겠습니까?",
                 description: "회원 탈퇴하면 계정을 복구할 수 없으며,\n    회원가입을 다시 진행해야 합니다!",
@@ -212,7 +224,7 @@ struct MyPageView: View {
     @ViewBuilder
     func adminUserListButton() -> some View {
         Button {
-            
+            viewModel.updateIsPresentedAdminUserListView(isPresented: true)
         } label: {
             BitgouelText(
                text: "사용자 명단 관리하기",

--- a/App/Sources/Feature/MyPageFeature/Source/MyPageView.swift
+++ b/App/Sources/Feature/MyPageFeature/Source/MyPageView.swift
@@ -168,6 +168,9 @@ struct MyPageView: View {
                     }
                 )
             )
+            .onChange(of: viewModel.isPresentedAdminUserListView) { newValue in
+                tabbarHidden.wrappedValue = newValue
+            }
             .bitgouelAlert(
                 title: "회원 탈퇴하시겠습니까?",
                 description: "회원 탈퇴하면 계정을 복구할 수 없으며,\n    회원가입을 다시 진행해야 합니다!",

--- a/App/Sources/Feature/MyPageFeature/Source/MyPageViewModel.swift
+++ b/App/Sources/Feature/MyPageFeature/Source/MyPageViewModel.swift
@@ -6,6 +6,7 @@ final class MyPageViewModel: BaseViewModel {
     @Published var isShowingWithdrawAlert: Bool = false
     @Published var isShowingLogoutAlert: Bool = false
     @Published var isPresentedChangePasswordView: Bool = false
+    @Published var isPresentedAdminUserListView: Bool = false
     
     var authority: UserAuthorityType = .user
     var userInfo: [String] = []
@@ -26,6 +27,10 @@ final class MyPageViewModel: BaseViewModel {
         self.fetchMyInfoUseCase = fetchMyInfoUseCase
         self.logoutUseCase = logoutUseCase
         self.withdrawalUseCase = withdrawalUseCase
+    }
+
+    func updateIsPresentedAdminUserListView(isPresented: Bool) {
+        isPresentedAdminUserListView = isPresented
     }
 
     func updateIsPresentedChangePasswordView(isPresented: Bool) {


### PR DESCRIPTION
## 💡 개요
사용자 명단 페이지 API 연결

## 📃 작업내용
어드민 사용자 명단페이지에 사용자 명단을 조회하는 기능을 추가했어요.
어드민일 때 사용자 명단 관리하기 Button 클릭 시 페이지로 이동하는 Action을 추가했어요.

## 🔀 변경사항
selectedAuthority가 nil일 때 빈 문자열로 요청을 보내야 해서 Optional값으로 변경했어요.
viewModel에 선언되어있던 Factory를 삭제 했어요.