### PR TITLE
🔀 :: [#246] 어드민 - 가입 요청자 명단 페이지 API 연결

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -397,6 +397,15 @@ private class AdminRequestUserSignupDependency260e3843e854d6971798Provider: Admi
     var adminWithdrawUserListFactory: any AdminWithdrawUserListFactory {
         return appComponent.adminWithdrawUserListFactory
     }
+    var fetchUserListUseCase: any FetchUserListUseCase {
+        return appComponent.fetchUserListUseCase
+    }
+    var approveUserSignupUseCase: any ApproveUserSignupUseCase {
+        return appComponent.approveUserSignupUseCase
+    }
+    var rejectUserSignupUseCase: any RejectUserSignupUseCase {
+        return appComponent.rejectUserSignupUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -827,6 +836,9 @@ extension AdminRequestUserSignupComponent: Registration {
     public func registerItems() {
         keyPathToName[\AdminRequestUserSignupDependency.adminUserListFactory] = "adminUserListFactory-any AdminUserListFactory"
         keyPathToName[\AdminRequestUserSignupDependency.adminWithdrawUserListFactory] = "adminWithdrawUserListFactory-any AdminWithdrawUserListFactory"
+        keyPathToName[\AdminRequestUserSignupDependency.fetchUserListUseCase] = "fetchUserListUseCase-any FetchUserListUseCase"
+        keyPathToName[\AdminRequestUserSignupDependency.approveUserSignupUseCase] = "approveUserSignupUseCase-any ApproveUserSignupUseCase"
+        keyPathToName[\AdminRequestUserSignupDependency.rejectUserSignupUseCase] = "rejectUserSignupUseCase-any RejectUserSignupUseCase"
     }
 }
 extension CertificationListComponent: Registration {

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupComponent.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupComponent.swift
@@ -5,6 +5,9 @@ import SwiftUI
 public protocol AdminRequestUserSignupDependency: Dependency {
     var adminUserListFactory: any AdminUserListFactory { get }
     var adminWithdrawUserListFactory: any AdminWithdrawUserListFactory { get }
+    var fetchUserListUseCase: any FetchUserListUseCase { get }
+    var approveUserSignupUseCase: any ApproveUserSignupUseCase { get }
+    var rejectUserSignupUseCase: any RejectUserSignupUseCase { get }
 }
 
 public final class AdminRequestUserSignupComponent: Component<AdminRequestUserSignupDependency>, AdminRequestUserSignupFactory {
@@ -12,8 +15,9 @@ public final class AdminRequestUserSignupComponent: Component<AdminRequestUserSi
     public func makeView() -> some View {
         AdminRequestUserSignupView(
             viewModel: .init(
-                adminUserListFactory: dependency.adminUserListFactory,
-                adminWithdrawUserListFactory: dependency.adminWithdrawUserListFactory
+                fetchUserListUseCase: dependency.fetchUserListUseCase,
+                approveUserSignupUseCase: dependency.approveUserSignupUseCase,
+                rejectUserSignupUseCase: dependency.rejectUserSignupUseCase
             ),
             adminUserListFactory: dependency.adminUserListFactory,
             adminWithdrawUserListFactory: dependency.adminWithdrawUserListFactory

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
@@ -41,31 +41,36 @@ struct AdminRequestUserSignupView: View {
                 }
                 .padding(.top, 24)
                 
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(0..<1) { _ in
-                        HStack(spacing: 8) {
-                            CheckButton(isSelected: $viewModel.isSelectedUserList)
-                            
-                            BitgouelText(
-                                text: "홍길동",
-                                font: .text1
-                            )
-                            
-                            BitgouelText(
-                                text: "학생",
-                                font: .text1
-                            )
-                            .foregroundColor(.bitgouel(.greyscale(.g6)))
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(viewModel.userList, id: \.userID) { userInfo in
+                            HStack(spacing: 8) {
+                                CheckButton(isSelected: $viewModel.isSelectedUserList)
+                                
+                                BitgouelText(
+                                    text: userInfo.name,
+                                    font: .text1
+                                )
+                                
+                                BitgouelText(
+                                    text: userInfo.authority.display(),
+                                    font: .text1
+                                )
+                                .foregroundColor(.bitgouel(.greyscale(.g6)))
+                            }
+
+                            Divider()
+                                .frame(height: 1)
+                                .padding(.vertical, 14)
                         }
-                        
-                        Divider()
-                            .frame(height: 1)
-                            .padding(.vertical, 14)
                     }
                 }
                 .padding(.top, 24)
                 
                 Spacer()
+            }
+            .onAppear {
+                viewModel.onAppear()
             }
             .padding(.horizontal, 28)
             .navigationTitle("가입 요청자 명단")

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
@@ -88,6 +88,9 @@ struct AdminRequestUserSignupView: View {
             .onAppear {
                 viewModel.onAppear()
             }
+            .refreshable {
+                viewModel.onAppear()
+            }
             .padding(.horizontal, 28)
             .navigationTitle("가입 요청자 명단")
             .toolbar {
@@ -121,6 +124,7 @@ struct AdminRequestUserSignupView: View {
                     },
                     .init(text: "수락", style: .default) {
                         viewModel.approveUserSignupButtonDidTap()
+                        viewModel.isShowingApproveAlert = false
                     }
                 ]
             )
@@ -132,7 +136,10 @@ struct AdminRequestUserSignupView: View {
                     .init(text: "취소", style: .cancel) {
                         viewModel.isShowingRejectAlert = false
                     },
-                    .init(text: "거절", style: .error) {}
+                    .init(text: "거절", style: .error) {
+                        viewModel.rejectUserSignupButtonDidTap()
+                        viewModel.isShowingRejectAlert = false
+                    }
                 ]
             )
         }

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
@@ -23,7 +23,15 @@ struct AdminRequestUserSignupView: View {
                     OptionButton(
                         buttonText: "전체 선택",
                         foregroundColor: .bitgouel(.greyscale(.g6))
-                    )
+                    ){
+                        if viewModel.isSelectedUserList {
+                            viewModel.removeAllUserList()
+                            viewModel.isSelectedUserList = false
+                        } else {
+                            viewModel.insertAllUserList()
+                            viewModel.isSelectedUserList = true
+                        }
+                    }
                     
                     OptionButton(
                         buttonText: "선택 수락",
@@ -45,7 +53,15 @@ struct AdminRequestUserSignupView: View {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(viewModel.userList, id: \.userID) { userInfo in
                             HStack(spacing: 8) {
-                                CheckButton(isSelected: $viewModel.isSelectedUserList)
+                                CheckButton(isSelected: Binding(
+                                    get: { viewModel.selectedUserList.contains(userInfo.userID) },
+                                    set: { isSelected in
+                                        viewModel.insertUserList(userID: userInfo.userID)
+                                        if !isSelected {
+                                            viewModel.removeUserList(userID: userInfo.userID)
+                                        }
+                                    })
+                                )
                                 
                                 BitgouelText(
                                     text: userInfo.name,

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
@@ -119,7 +119,9 @@ struct AdminRequestUserSignupView: View {
                     .init(text: "취소", style: .cancel) {
                         viewModel.isShowingApproveAlert = false
                     },
-                    .init(text: "수락", style: .default) {}
+                    .init(text: "수락", style: .default) {
+                        viewModel.approveUserSignupButtonDidTap()
+                    }
                 ]
             )
             .bitgouelAlert(

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
@@ -54,6 +54,16 @@ final class AdminRequestUserSignupViewModel: BaseViewModel {
             }
         }
     }
+
+    func approveUserSignupButtonDidTap() {
+        Task {
+            do {
+                try await approveUserSignupUseCase(userID: Array(selectedUserList).joined(separator: ", "))
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
     
     @MainActor
     func userListPageDismissed() {

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
@@ -58,7 +58,17 @@ final class AdminRequestUserSignupViewModel: BaseViewModel {
     func approveUserSignupButtonDidTap() {
         Task {
             do {
-                try await approveUserSignupUseCase(userID: Array(selectedUserList).joined(separator: ", "))
+                try await approveUserSignupUseCase(userID: Array(selectedUserList).joined(separator: ","))
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
+    func rejectUserSignupButtonDidTap() {
+        Task {
+            do {
+                try await rejectUserSignupUseCase(userID: Array(selectedUserList).joined(separator: ","))
             } catch {
                 print(error.localizedDescription)
             }

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
@@ -8,6 +8,7 @@ final class AdminRequestUserSignupViewModel: BaseViewModel {
     @Published var isNavigateUserListDidTap: Bool = false
     @Published var isNavigateWithdrawListDidTap: Bool = false
     @Published var userList: [UserInfoEntity] = []
+    @Published var selectedUserList: Set<String> = []
 
     let approveStatus: ApproveStatusType = .pending
     private let fetchUserListUseCase: any FetchUserListUseCase
@@ -22,6 +23,23 @@ final class AdminRequestUserSignupViewModel: BaseViewModel {
         self.fetchUserListUseCase = fetchUserListUseCase
         self.approveUserSignupUseCase = approveUserSignupUseCase
         self.rejectUserSignupUseCase = rejectUserSignupUseCase
+    }
+
+    func insertAllUserList() {
+        let userIDs = userList.map(\.userID)
+        selectedUserList.formUnion(userIDs)
+    }
+
+    func removeAllUserList() {
+        selectedUserList.removeAll()
+    }
+
+    func insertUserList(userID: String) {
+        selectedUserList.insert(userID)
+    }
+
+    func removeUserList(userID: String) {
+        selectedUserList.remove(userID)
     }
 
     @MainActor

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupViewModel.swift
@@ -1,21 +1,40 @@
 import Foundation
+import Service
 
 final class AdminRequestUserSignupViewModel: BaseViewModel {
     @Published var isShowingApproveAlert: Bool = false
     @Published var isShowingRejectAlert: Bool = false
-    @Published var isSelectedUserList = false
-    @Published var isNavigateUserListDidTap = false
-    @Published var isNavigateWithdrawListDidTap = false
-    
-    private let adminUserListFactory: any AdminUserListFactory
-    private let adminWithdrawUserListFactory: any AdminWithdrawUserListFactory
+    @Published var isSelectedUserList: Bool = false
+    @Published var isNavigateUserListDidTap: Bool = false
+    @Published var isNavigateWithdrawListDidTap: Bool = false
+    @Published var userList: [UserInfoEntity] = []
+
+    let approveStatus: ApproveStatusType = .pending
+    private let fetchUserListUseCase: any FetchUserListUseCase
+    private let approveUserSignupUseCase: any ApproveUserSignupUseCase
+    private let rejectUserSignupUseCase: any RejectUserSignupUseCase
     
     init(
-        adminUserListFactory: any AdminUserListFactory,
-        adminWithdrawUserListFactory: any AdminWithdrawUserListFactory
+        fetchUserListUseCase: any FetchUserListUseCase,
+        approveUserSignupUseCase: any ApproveUserSignupUseCase,
+        rejectUserSignupUseCase: any RejectUserSignupUseCase
     ) {
-        self.adminUserListFactory = adminUserListFactory
-        self.adminWithdrawUserListFactory = adminWithdrawUserListFactory
+        self.fetchUserListUseCase = fetchUserListUseCase
+        self.approveUserSignupUseCase = approveUserSignupUseCase
+        self.rejectUserSignupUseCase = rejectUserSignupUseCase
+    }
+
+    @MainActor
+    func onAppear() {
+        Task {
+            do {
+                userList = try await fetchUserListUseCase(
+                    keyword: "",
+                    authority: "",
+                    approveStatus: approveStatus.rawValue
+                )
+            }
+        }
     }
     
     @MainActor

--- a/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListView.swift
+++ b/App/Sources/Feature/AdminUserListFeature/Source/AdminUserListView.swift
@@ -94,6 +94,9 @@ struct AdminUserListView: View {
         .onAppear {
             viewModel.onAppear()
         }
+        .refreshable {
+            viewModel.onAppear()
+        }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 Button {

--- a/Service/Sources/Data/DataSource/Admin/RemoteAdminDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/Admin/RemoteAdminDataSourceImpl.swift
@@ -19,15 +19,15 @@ public final class RemoteAdminDataSourceImpl: BaseRemoteDataSource<AdminAPI>, Re
         ).toDomain()
     }
 
-    public func approveUserSignup(userID: [String]) async throws {
+    public func approveUserSignup(userID: String) async throws {
         try await request(.approveUserSignup(userID: userID))
     }
 
-    public func rejectUserSignup(userID: [String]) async throws {
+    public func rejectUserSignup(userID: String) async throws {
         try await request(.rejectUserSignup(userID: userID))
     }
 
-    public func withdrawUserSignup(userID: [String]) async throws {
+    public func withdrawUserSignup(userID: String) async throws {
         try await request(.withdrawUserSignup(userID: userID))
     }
 }

--- a/Service/Sources/Data/Repository/Admin/AdminRespositoryImpl.swift
+++ b/Service/Sources/Data/Repository/Admin/AdminRespositoryImpl.swift
@@ -23,15 +23,15 @@ public struct AdminRespositoryImpl: AdminRepository {
         try await remoteAdminDataSource.fetchUserDetail(userID: userID)
     }
 
-    public func approveUserSignup(userID: [String]) async throws {
+    public func approveUserSignup(userID: String) async throws {
         try await remoteAdminDataSource.approveUserSignup(userID: userID)
     }
 
-    public func rejectUserSignup(userID: [String]) async throws {
+    public func rejectUserSignup(userID: String) async throws {
         try await remoteAdminDataSource.rejectUserSignup(userID: userID)
     }
 
-    public func withdrawUserSignup(userID: [String]) async throws {
+    public func withdrawUserSignup(userID: String) async throws {
         try await remoteAdminDataSource.withdrawUserSignup(userID: userID)
     }
 }

--- a/Service/Sources/Data/UseCase/Admin/ApproveUserSignupUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/Admin/ApproveUserSignupUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct ApproveUserSignupUseCaseImpl: ApproveUserSignupUseCase {
         self.adminRepository = adminRepository
     }
 
-    public func callAsFunction(userID: [String]) async throws {
+    public func callAsFunction(userID: String) async throws {
         try await adminRepository.approveUserSignup(userID: userID)
     }
 }

--- a/Service/Sources/Data/UseCase/Admin/RejectUserSignupUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/Admin/RejectUserSignupUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct RejectUserSignupUseCaseImpl: RejectUserSignupUseCase {
         self.adminRepository = adminRepository
     }
 
-    public func callAsFunction(userID: [String]) async throws {
+    public func callAsFunction(userID: String) async throws {
         try await adminRepository.rejectUserSignup(userID: userID)
     }
 }

--- a/Service/Sources/Data/UseCase/Admin/WithdrawUserUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/Admin/WithdrawUserUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct WithdrawUserUseCaseImpl: WithdrawUserUseCase {
         self.adminRepository = adminRepository
     }
 
-    public func callAsFunction(userID: [String]) async throws {
+    public func callAsFunction(userID: String) async throws {
         try await adminRepository.withdrawUserSignup(userID: userID)
     }
 }

--- a/Service/Sources/Domain/AdminDomain/API/AdminAPI.swift
+++ b/Service/Sources/Domain/AdminDomain/API/AdminAPI.swift
@@ -4,9 +4,9 @@ import Moya
 public enum AdminAPI {
     case fetchUserList(keyword: String, authority: String, approveStatus: String)
     case fetchUserDetail(userID: String)
-    case approveUserSignup(userID: [String])
-    case rejectUserSignup(userID: [String])
-    case withdrawUserSignup(userID: [String])
+    case approveUserSignup(userID: String)
+    case rejectUserSignup(userID: String)
+    case withdrawUserSignup(userID: String)
 }
 
 extension AdminAPI: BitgouelAPI {

--- a/Service/Sources/Domain/AdminDomain/DataSource/RemoteAdminDataSource.swift
+++ b/Service/Sources/Domain/AdminDomain/DataSource/RemoteAdminDataSource.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol RemoteAdminDataSource {
     func fetchUserList(keyword: String, authority: String, approveStatus: String) async throws -> [UserInfoEntity]
     func fetchUserDetail(userID: String) async throws -> UserInfoEntity
-    func approveUserSignup(userID: [String]) async throws
-    func rejectUserSignup(userID: [String]) async throws
-    func withdrawUserSignup(userID: [String]) async throws
+    func approveUserSignup(userID: String) async throws
+    func rejectUserSignup(userID: String) async throws
+    func withdrawUserSignup(userID: String) async throws
 }

--- a/Service/Sources/Domain/AdminDomain/Repository/AdminRepository.swift
+++ b/Service/Sources/Domain/AdminDomain/Repository/AdminRepository.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol AdminRepository {
     func fetchUserList(keyword: String, authority: String, approveStatus: String) async throws -> [UserInfoEntity]
     func fetchUserDetail(userID: String) async throws -> UserInfoEntity
-    func approveUserSignup(userID: [String]) async throws
-    func rejectUserSignup(userID: [String]) async throws
-    func withdrawUserSignup(userID: [String]) async throws
+    func approveUserSignup(userID: String) async throws
+    func rejectUserSignup(userID: String) async throws
+    func withdrawUserSignup(userID: String) async throws
 }

--- a/Service/Sources/Domain/AdminDomain/UseCase/ApproveUserSignupUseCase.swift
+++ b/Service/Sources/Domain/AdminDomain/UseCase/ApproveUserSignupUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol ApproveUserSignupUseCase {
-    func callAsFunction(userID: [String]) async throws
+    func callAsFunction(userID: String) async throws
 }

--- a/Service/Sources/Domain/AdminDomain/UseCase/RejectUserSignupUseCase.swift
+++ b/Service/Sources/Domain/AdminDomain/UseCase/RejectUserSignupUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol RejectUserSignupUseCase {
-    func callAsFunction(userID: [String]) async throws
+    func callAsFunction(userID: String) async throws
 }

--- a/Service/Sources/Domain/AdminDomain/UseCase/WithdrawUserSignupUseCase.swift
+++ b/Service/Sources/Domain/AdminDomain/UseCase/WithdrawUserSignupUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol WithdrawUserUseCase {
-    func callAsFunction(userID: [String]) async throws
+    func callAsFunction(userID: String) async throws
 }


### PR DESCRIPTION
## 💡 개요
가입 요청자 명단 페이지 API 연결

## 📃 작업내용
가입 요청자 명단 리스트를 조회하는 기능을 추가했어요.
유저 선택, 전체 선택 기능을 추가했어요.
유저 가입요청 수락 기능을 추가했어요.
유저 가입요청 거절 기능을 추가했어요.

## 🔀 변경사항
userID를 보낼 때 잘 못된 부분이 있어서 수정했어요.
