### PR TITLE
🔀 :: [#246] 어드민 - 탈퇴 예정자 명단 페이지 API 연결

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -450,6 +450,12 @@ private class AdminWithdrawUserListDependency06942465f0ac1aaeda24Provider: Admin
     var adminRequestUserSignupFactory: any AdminRequestUserSignupFactory {
         return appComponent.adminRequestUserSignupFactory
     }
+    var fetchWithdrawUserListUseCase: any FetchWithdrawUserListUseCase {
+        return appComponent.fetchWithdrawUserListUseCase
+    }
+    var withdrawUserUseCase: any WithdrawUserUseCase {
+        return appComponent.withdrawUserUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -855,6 +861,8 @@ extension AdminWithdrawUserListComponent: Registration {
     public func registerItems() {
         keyPathToName[\AdminWithdrawUserListDependency.adminUserListFactory] = "adminUserListFactory-any AdminUserListFactory"
         keyPathToName[\AdminWithdrawUserListDependency.adminRequestUserSignupFactory] = "adminRequestUserSignupFactory-any AdminRequestUserSignupFactory"
+        keyPathToName[\AdminWithdrawUserListDependency.fetchWithdrawUserListUseCase] = "fetchWithdrawUserListUseCase-any FetchWithdrawUserListUseCase"
+        keyPathToName[\AdminWithdrawUserListDependency.withdrawUserUseCase] = "withdrawUserUseCase-any WithdrawUserUseCase"
     }
 }
 extension WriteInquiryAnswerComponent: Registration {

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListComponent.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListComponent.swift
@@ -5,6 +5,8 @@ import SwiftUI
 public protocol AdminWithdrawUserListDependency: Dependency {
     var adminUserListFactory: any AdminUserListFactory { get }
     var adminRequestUserSignupFactory: any AdminRequestUserSignupFactory { get }
+    var fetchWithdrawUserListUseCase: any FetchWithdrawUserListUseCase { get }
+    var withdrawUserUseCase: any WithdrawUserUseCase { get }
 }
 
 public final class AdminWithdrawUserListComponent: Component<AdminWithdrawUserListDependency>, AdminWithdrawUserListFactory {
@@ -12,8 +14,8 @@ public final class AdminWithdrawUserListComponent: Component<AdminWithdrawUserLi
     public func makeView() -> some View {
         AdminWithdrawUserListView(
             viewModel: .init(
-                adminUserListFactory: dependency.adminUserListFactory,
-                adminRequestUserSignupFactory: dependency.adminRequestUserSignupFactory
+                fetchWithdrawUserListUseCase: dependency.fetchWithdrawUserListUseCase,
+                withdrawUserUseCase: dependency.withdrawUserUseCase
             ),
             adminUserListFactory: dependency.adminUserListFactory,
             adminRequestUserSignupFactory: dependency.adminRequestUserSignupFactory

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
@@ -36,7 +36,12 @@ struct AdminWithdrawUserListView: View {
                         strokeColor: .bitgouel(.error(.e5)),
                         backgroundColor: .bitgouel(.error(.e5))
                     ) {
-                        viewModel.isShowingWithdrawAlert = true
+                        if viewModel.isShowingWithdrawAlert {
+                            viewModel.isShowingWithdrawAlert = false
+                        } else {
+                            viewModel.isShowingWithdrawAlert = true
+                            viewModel.insertAllUserList()
+                        }
                     }
                     
                     HStack {
@@ -61,20 +66,24 @@ struct AdminWithdrawUserListView: View {
                 .padding(.top, 24)
                 
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(0..<1) { _ in
+                    ForEach(viewModel.userList, id: \.userID) { userInfo in
                         HStack(spacing: 8) {
-                            CheckButton(isSelected: $viewModel.isSelectedUserList)
-                            
-                            BitgouelText(
-                                text: "홍길동",
-                                font: .text1
+                            CheckButton(
+                                isSelected: Binding(
+                                    get: { viewModel.selectedWithdrawUserList.contains(userInfo.userID) },
+                                    set: { isSelected in
+                                        viewModel.insertUserList(userID: userInfo.userID)
+                                        if !isSelected {
+                                            viewModel.removeUserList(userID: userInfo.userID)
+                                        }
+                                    }
+                                )
                             )
                             
                             BitgouelText(
-                                text: "학생",
+                                text: userInfo.name,
                                 font: .text1
                             )
-                            .foregroundColor(.bitgouel(.greyscale(.g6)))
                         }
                         
                         Divider()
@@ -87,42 +96,53 @@ struct AdminWithdrawUserListView: View {
                 Spacer()
             }
             .padding(.horizontal, 28)
-            .navigationTitle("사용자 명단")
-            .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button {
-                        viewModel.isNavigateUserListDidTap = true
-                    } label: {
-                        BitgouelAsset.Icons.people.swiftUIImage
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 24, height: 24)
-                    }
-                    
-                    Button {
-                        viewModel.isNavigateRequestSignUpDidTap = true
-                    } label: {
-                        BitgouelAsset.Icons.addFill.swiftUIImage
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 24, height: 24)
-                    }
-                }
-            }
+            
             ZStack(alignment: .center) {
                 if viewModel.isPresentedUserCohortFilter {
                     Color.black.opacity(0.4)
                         .edgesIgnoringSafeArea(.all)
+                        .onTapGesture {
+                            viewModel.updateIsPresentedCohortFilter(isPresented: false)
+                        }
                     
                     UserCohortFilterPopup(
-                        cohortList: viewModel.cohortList,
-                        selectedCohort: viewModel.selectedCohort
-                    ) { cohort in
-                        viewModel.selectedCohort = cohort
-                    } cancel: { cancel in
-                        viewModel.updateIsPresentedCohortFilter(isPresented: cancel)
-                    }
+                        currentYear: viewModel.currentYear,
+                        selectedCohort: viewModel.selectedCohort,
+                        onCohortSelect: { cohort in
+                            viewModel.selectedCohort = cohort
+                            viewModel.onAppear()
+                        },
+                        cancel: { cancel in
+                            viewModel.updateIsPresentedCohortFilter(isPresented: cancel)
+                        }
+                    )
                     .padding(.horizontal, 28)
+                }
+            }
+            .zIndex(1)
+        }
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .navigationTitle("탈퇴 예정자 명단")
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button {
+                    viewModel.isNavigateUserListDidTap = true
+                } label: {
+                    BitgouelAsset.Icons.people.swiftUIImage
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 24, height: 24)
+                }
+                
+                Button {
+                    viewModel.isNavigateRequestSignUpDidTap = true
+                } label: {
+                    BitgouelAsset.Icons.addFill.swiftUIImage
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 24, height: 24)
                 }
             }
         }
@@ -133,6 +153,7 @@ struct AdminWithdrawUserListView: View {
             alertActions: [
                 .init(text: "취소", style: .cancel) {
                     viewModel.isShowingWithdrawAlert = false
+                    viewModel.removeAllUserList()
                 },
                 .init(text: "승인", style: .error)
             ]

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
@@ -155,7 +155,10 @@ struct AdminWithdrawUserListView: View {
                     viewModel.isShowingWithdrawAlert = false
                     viewModel.removeAllUserList()
                 },
-                .init(text: "승인", style: .error)
+                .init(text: "승인", style: .error) {
+                    viewModel.withdrawUser()
+                    viewModel.isShowingWithdrawAlert = false
+                }
             ]
         )
         .navigate(

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListViewModel.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListViewModel.swift
@@ -50,6 +50,16 @@ final class AdminWithdrawUserListViewModel: BaseViewModel {
         isPresentedUserCohortFilter = isPresented
     }
 
+    func withdrawUser() {
+        Task {
+            do {
+                try await withdrawUserUseCase(userID: selectedWithdrawUserList.joined(separator: ","))
+            } catch {
+                print(String(describing: error))
+            }
+        }
+    }
+
     @MainActor
     func onAppear() {
         Task {

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListViewModel.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListViewModel.swift
@@ -4,27 +4,63 @@ import Service
 final class AdminWithdrawUserListViewModel: BaseViewModel {
     @Published var isShowingWithdrawAlert: Bool = false
     @Published var isSelectedUserList = false
-    @Published var isPresentedUserCohortFilter: Bool = false
+    @Published var isPresentedUserCohortFilter: Bool = true
     @Published var isNavigateUserListDidTap = false
     @Published var isNavigateRequestSignUpDidTap = false
-    @Published var selectedCohort: CohortList = .first
-    
-    private let adminUserListFactory: any AdminUserListFactory
-    private let adminRequestUserSignupFactory: any AdminRequestUserSignupFactory
-    var cohortList: [CohortList] = CohortList.allCases
-    
-    init(
-        adminUserListFactory: any AdminUserListFactory,
-        adminRequestUserSignupFactory: any AdminRequestUserSignupFactory
-    ) {
-        self.adminUserListFactory = adminUserListFactory
-        self.adminRequestUserSignupFactory = adminRequestUserSignupFactory
+    @Published var userList: [WithdrawUserInfoEntity] = []
+    @Published var selectedWithdrawUserList: Set<String> = []
+    @Published var selectedCohort: Int = 0
+
+    var currentYear: Int {
+        let currentDate = Date()
+        let calendar = Calendar.current
+        return calendar.component(.year, from: currentDate)
     }
-    
+
+    private let fetchWithdrawUserListUseCase: any FetchWithdrawUserListUseCase
+    private let withdrawUserUseCase: any WithdrawUserUseCase
+
+    init(
+        fetchWithdrawUserListUseCase: any FetchWithdrawUserListUseCase,
+        withdrawUserUseCase: any WithdrawUserUseCase
+    ) {
+        self.fetchWithdrawUserListUseCase = fetchWithdrawUserListUseCase
+        self.withdrawUserUseCase = withdrawUserUseCase
+    }
+
+    func insertAllUserList() {
+        let userIDs = userList.map(\.userID)
+        selectedWithdrawUserList.formUnion(userIDs)
+    }
+
+    func removeAllUserList() {
+        selectedWithdrawUserList.removeAll()
+    }
+
+
+    func insertUserList(userID: String) {
+        selectedWithdrawUserList.insert(userID)
+    }
+
+    func removeUserList(userID: String) {
+        selectedWithdrawUserList.remove(userID)
+    }
+
     func updateIsPresentedCohortFilter(isPresented: Bool) {
         isPresentedUserCohortFilter = isPresented
     }
-    
+
+    @MainActor
+    func onAppear() {
+        Task {
+            do {
+                userList = try await fetchWithdrawUserListUseCase(cohort: selectedCohort.description)
+            } catch {
+                print(String(describing: error))
+            }
+        }
+    }
+
     @MainActor
     func userListPageDismissed() {
         isNavigateUserListDidTap = false

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/Component/UserCohortFilterPopup.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/Component/UserCohortFilterPopup.swift
@@ -1,83 +1,9 @@
-import SwiftUI
-import Service
+//
+//  User.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 3/22/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
 
-enum CohortList: String, CaseIterable {
-    case first = "1기"
-    case second = "2기"
-    case third = "3기"
-    case fourth = "4기"
-}
-
-struct UserCohortFilterPopup: View {
-    let cohortList: [CohortList]
-    var selectedCohort: CohortList?
-    let onCohortSelect: (CohortList) -> Void
-    let cancel: (Bool) -> Void
-    
-    var body: some View {
-        RoundedRectangle(cornerRadius: 8)
-            .fill(Color.white)
-            .frame(height: 280)
-            .overlay {
-                VStack(spacing: 0) {
-                    HStack {
-                        BitgouelText(
-                            text: "기수",
-                            font: .title3
-                        )
-                        
-                        Spacer()
-                        
-                        Button {
-                            cancel(false)
-                        } label: {
-                            BitgouelAsset.Icons.cancel.swiftUIImage
-                        }
-                    }
-                    .padding(.top, 24)
-                    
-                    Spacer()
-                    
-                    VStack(spacing: 16) {
-                        ForEach(cohortList, id: \.self) { cohort in
-                            userCohortTypeRow(
-                                cohort: cohort,
-                                selectedCohort: selectedCohort,
-                                onCohortSelect: onCohortSelect)
-                        }
-                        
-                        Spacer()
-                    }
-                    .padding(.top, 32)
-                }
-                .padding(.horizontal, 24)
-            }
-    }
-    
-    @ViewBuilder
-    func userCohortTypeRow(
-        cohort: CohortList,
-        selectedCohort: CohortList?,
-        onCohortSelect: @escaping (CohortList) -> Void
-    ) -> some View {
-        HStack(spacing: 8) {
-            BitgouelRadioButton(
-                isSelected: Binding(
-                    get: { selectedCohort?.rawValue == cohort.rawValue },
-                    set: { isSelected in
-                        if isSelected {
-                            onCohortSelect(cohort)
-                        }
-                    }
-                )
-            )
-            
-            BitgouelText(
-                text: cohort.rawValue,
-                font: .text3
-            )
-            
-            Spacer()
-        }
-    }
-}
+import Foundation

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/Component/UserCohortFilterPopup.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/Component/UserCohortFilterPopup.swift
@@ -1,9 +1,79 @@
-//
-//  User.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 3/22/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
+import SwiftUI
+import Service
 
-import Foundation
+struct UserCohortFilterPopup: View {
+    let currentYear: Int
+    var selectedCohort: Int
+    let onCohortSelect: (Int) -> Void
+    let cancel: (Bool) -> Void
+    
+    var body: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.white)
+            .frame(height: 280)
+            .overlay {
+                VStack(spacing: 0) {
+                    HStack {
+                        BitgouelText(
+                            text: "기수",
+                            font: .title3
+                        )
+                        
+                        Spacer()
+                        
+                        Button {
+                            cancel(false)
+                        } label: {
+                            BitgouelAsset.Icons.cancel.swiftUIImage
+                        }
+                    }
+                    .padding(.top, 24)
+                    
+                    Spacer()
+                    
+                    ScrollView {
+                        VStack(spacing: 16) {
+                            ForEach(2022...currentYear, id: \.self) { cohort in
+                                userCohortTypeRow(
+                                    cohort: cohort - 2021,
+                                    selectedCohort: selectedCohort,
+                                    onCohortSelect: onCohortSelect)
+                            }
+                            
+                            Spacer()
+                        }
+                    }
+                    .padding(.top, 32)
+
+                }
+                .padding(.horizontal, 24)
+            }
+    }
+    
+    @ViewBuilder
+    func userCohortTypeRow(
+        cohort: Int,
+        selectedCohort: Int?,
+        onCohortSelect: @escaping (Int) -> Void
+    ) -> some View {
+        HStack(spacing: 8) {
+            BitgouelRadioButton(
+                isSelected: Binding(
+                    get: { selectedCohort == cohort },
+                    set: { isSelected in
+                        if isSelected {
+                            onCohortSelect(cohort)
+                        }
+                    }
+                )
+            )
+            
+            BitgouelText(
+                text: "\(cohort)기",
+                font: .text3
+            )
+            
+            Spacer()
+        }
+    }
+}

--- a/Service/Sources/Domain/AdminDomain/API/AdminAPI.swift
+++ b/Service/Sources/Domain/AdminDomain/API/AdminAPI.swift
@@ -25,8 +25,8 @@ extension AdminAPI: BitgouelAPI {
         case let .fetchUserDetail(userID):
             return "/\(userID)"
 
-        case let .withdrawUserSignup(userID):
-            return "/\(userID)"
+        case .withdrawUserSignup:
+            return "/withdraw"
 
         case let .rejectUserSignup(userID):
             return "/reject"
@@ -58,13 +58,13 @@ extension AdminAPI: BitgouelAPI {
             ], encoding: URLEncoding.queryString)
 
         case let .approveUserSignup(userID),
-             let .rejectUserSignup(userID):
+             let .rejectUserSignup(userID),
+             let .withdrawUserSignup(userID):
             return .requestParameters(parameters: [
                 "userIds": userID
             ], encoding: URLEncoding.queryString)
 
-        case .fetchUserDetail,
-             .withdrawUserSignup:
+        case .fetchUserDetail:
             return .requestPlain
         }
     }

--- a/Service/Sources/Domain/WithdrawDomain/DTO/Response/FetchWithdrawUserListResponseDTO.swift
+++ b/Service/Sources/Domain/WithdrawDomain/DTO/Response/FetchWithdrawUserListResponseDTO.swift
@@ -8,12 +8,12 @@ public struct FetchWithdrawUserListResponseDTO: Decodable {
     }
 
     public struct WithdrawUserInfo: Decodable {
-        public let withdrawID: String
+        public let withdrawID: Int
         public let userID: String
         public let name: String
 
         public init(
-            withdrawID: String,
+            withdrawID: Int,
             userID: String,
             name: String
         ) {
@@ -25,7 +25,7 @@ public struct FetchWithdrawUserListResponseDTO: Decodable {
         enum CodingKeys: String, CodingKey {
             case withdrawID = "withdrawId"
             case userID = "userId"
-            case name
+            case name = "studentName"
         }
     }
 }

--- a/Service/Sources/Domain/WithdrawDomain/Entity/WithdrawUserInfoEntity.swift
+++ b/Service/Sources/Domain/WithdrawDomain/Entity/WithdrawUserInfoEntity.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public struct WithdrawUserInfoEntity: Equatable {
-    public let withdrawID: String
+    public let withdrawID: Int
     public let userID: String
     public let name: String
 
     public init(
-        withdrawID: String,
+        withdrawID: Int,
         userID: String,
         name: String
     ) {


### PR DESCRIPTION
## 💡 개요
어드민 - 탈퇴 예정자 명단 페이지 API 연결

## 📃 작업내용
탈퇴 예정자 조회 기능을 추가했어요.
유저 강제 탈퇴 기능 추가했어요.

## 🔀 변경사항
navigationTitle이 사용자 명단에서 탈퇴 예정자 명단으로 변경했어요.
withdrawID의 Type을 String에서 Int로 변경했어요.

