### PR TITLE
🔀 :: [#252] 비밀번호 찾기 - 비밀번호 변경 페이지 퍼블리싱

### DIFF
--- a/App/Sources/Application/DI/AppComponent.swift
+++ b/App/Sources/Application/DI/AppComponent.swift
@@ -158,4 +158,8 @@ public extension AppComponent {
     var findPasswordFactory: any FindPasswordFactory {
         FindPasswordComponent(parent: self)
     }
+
+    var newPasswordFactory: any NewPasswordFactory {
+        NewPasswordComponent(parent: self)
+    }
 }

--- a/App/Sources/Application/DI/Email/AppComponent+Email.swift
+++ b/App/Sources/Application/DI/Email/AppComponent+Email.swift
@@ -20,7 +20,7 @@ public extension AppComponent {
         }
     }
     
-    var fetchEmailVerificationStatusUseCase: any FetchEmailVertificationStatusUseCase {
+    var fetchEmailVertificationStatusUseCase: any FetchEmailVertificationStatusUseCase {
         shared {
             FetchEmailVerificationStatusUseCaseImpl(emailRepository: emailRepository)
         }

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -397,6 +397,12 @@ private class FindPasswordDependency542eacce769b9dc25904Provider: FindPasswordDe
     var sendEmailCertificationLinkUseCase: any SendEmailCertificationLinkUseCase {
         return appComponent.sendEmailCertificationLinkUseCase
     }
+    var fetchEmailVertificationStatusUseCase: any FetchEmailVertificationStatusUseCase {
+        return appComponent.fetchEmailVertificationStatusUseCase
+    }
+    var newPasswordFactory: any NewPasswordFactory {
+        return appComponent.newPasswordFactory
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -525,6 +531,17 @@ private class SuccessChangePasswordDependency05dde412f91beb4c3b8dProvider: Succe
 /// ^->AppComponent->SuccessChangePasswordComponent
 private func factoryde3552d9e0f793ec8b8df47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
     return SuccessChangePasswordDependency05dde412f91beb4c3b8dProvider(appComponent: parent1(component) as! AppComponent)
+}
+private class NewPasswordDependency3320cbf6e40b8cd8a8eaProvider: NewPasswordDependency {
+
+
+    init() {
+
+    }
+}
+/// ^->AppComponent->NewPasswordComponent
+private func factory52985a6d5ec65d75bd97e3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return NewPasswordDependency3320cbf6e40b8cd8a8eaProvider()
 }
 private class InquiryListDependencyec75a7335a50ded93b28Provider: InquiryListDependency {
     var inputInquiryFactory: any InputInquiryFactory {
@@ -874,6 +891,8 @@ extension SuccessSignUpComponent: Registration {
 extension FindPasswordComponent: Registration {
     public func registerItems() {
         keyPathToName[\FindPasswordDependency.sendEmailCertificationLinkUseCase] = "sendEmailCertificationLinkUseCase-any SendEmailCertificationLinkUseCase"
+        keyPathToName[\FindPasswordDependency.fetchEmailVertificationStatusUseCase] = "fetchEmailVertificationStatusUseCase-any FetchEmailVertificationStatusUseCase"
+        keyPathToName[\FindPasswordDependency.newPasswordFactory] = "newPasswordFactory-any NewPasswordFactory"
     }
 }
 extension AdminRequestUserSignupComponent: Registration {
@@ -918,6 +937,11 @@ extension PostDetailComponent: Registration {
 extension SuccessChangePasswordComponent: Registration {
     public func registerItems() {
         keyPathToName[\SuccessChangePasswordDependency.myPageFactory] = "myPageFactory-any MyPageFactory"
+    }
+}
+extension NewPasswordComponent: Registration {
+    public func registerItems() {
+
     }
 }
 extension InquiryListComponent: Registration {
@@ -1103,13 +1127,14 @@ extension AppComponent: Registration {
         localTable["adminRequestUserSignupFactory-any AdminRequestUserSignupFactory"] = { [unowned self] in self.adminRequestUserSignupFactory as Any }
         localTable["adminWithdrawUserListFactory-any AdminWithdrawUserListFactory"] = { [unowned self] in self.adminWithdrawUserListFactory as Any }
         localTable["findPasswordFactory-any FindPasswordFactory"] = { [unowned self] in self.findPasswordFactory as Any }
+        localTable["newPasswordFactory-any NewPasswordFactory"] = { [unowned self] in self.newPasswordFactory as Any }
         localTable["remoteWithdrawDataSource-any RemoteWithdrawDataSource"] = { [unowned self] in self.remoteWithdrawDataSource as Any }
         localTable["withdrawRepository-any WithdrawRepository"] = { [unowned self] in self.withdrawRepository as Any }
         localTable["fetchWithdrawUserListUseCase-any FetchWithdrawUserListUseCase"] = { [unowned self] in self.fetchWithdrawUserListUseCase as Any }
         localTable["remoteEmailDataSource-any RemoteEmailDataSource"] = { [unowned self] in self.remoteEmailDataSource as Any }
         localTable["emailRepository-any EmailRepository"] = { [unowned self] in self.emailRepository as Any }
         localTable["sendEmailCertificationLinkUseCase-any SendEmailCertificationLinkUseCase"] = { [unowned self] in self.sendEmailCertificationLinkUseCase as Any }
-        localTable["fetchEmailVerificationStatusUseCase-any FetchEmailVertificationStatusUseCase"] = { [unowned self] in self.fetchEmailVerificationStatusUseCase as Any }
+        localTable["fetchEmailVertificationStatusUseCase-any FetchEmailVertificationStatusUseCase"] = { [unowned self] in self.fetchEmailVertificationStatusUseCase as Any }
         localTable["remoteCertificationDataSource-any RemoteCertificationDataSource"] = { [unowned self] in self.remoteCertificationDataSource as Any }
         localTable["certificationRepository-any CertificationRepository"] = { [unowned self] in self.certificationRepository as Any }
         localTable["queryCertificationListByTeacherUseCase-any QueryCertificationListByTeacherUseCase"] = { [unowned self] in self.queryCertificationListByTeacherUseCase as Any }
@@ -1160,6 +1185,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->WriteInquiryAnswerComponent", factory3d4cadf14cd9a3336981f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->PostDetailComponent", factorybc555a73df3767a26999f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->SuccessChangePasswordComponent", factoryde3552d9e0f793ec8b8df47b58f8f304c97af4d5)
+    registerProviderFactory("^->AppComponent->NewPasswordComponent", factory52985a6d5ec65d75bd97e3b0c44298fc1c149afb)
     registerProviderFactory("^->AppComponent->InquiryListComponent", factorydd7e28250a180554c7a0f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->EditPostComponent", factoryf55a9d7f6c1ed8d0f0aef47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->ActivityListComponent", factory7177e6769ee69064a61bf47b58f8f304c97af4d5)

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -305,6 +305,9 @@ private class RootDependency3944cc797a4a88956fb5Provider: RootDependency {
     var mainTabFactory: any MainTabFactory {
         return appComponent.mainTabFactory
     }
+    var findPasswordFactory: any FindPasswordFactory {
+        return appComponent.findPasswordFactory
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -857,6 +860,7 @@ extension RootComponent: Registration {
     public func registerItems() {
         keyPathToName[\RootDependency.loginFactory] = "loginFactory-any LoginFactory"
         keyPathToName[\RootDependency.mainTabFactory] = "mainTabFactory-any MainTabFactory"
+        keyPathToName[\RootDependency.findPasswordFactory] = "findPasswordFactory-any FindPasswordFactory"
     }
 }
 extension PostListComponent: Registration {

--- a/App/Sources/Feature/BaseFeature/Flow/SceneFlow.swift
+++ b/App/Sources/Feature/BaseFeature/Flow/SceneFlow.swift
@@ -3,4 +3,5 @@ import Foundation
 public enum SceneFlow: String, RawRepresentable {
     case login
     case main
+    case findPassword
 }

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordComponent.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordComponent.swift
@@ -4,14 +4,18 @@ import Service
 
 public protocol FindPasswordDependency: Dependency {
     var sendEmailCertificationLinkUseCase: any SendEmailCertificationLinkUseCase { get }
+    var fetchEmailVertificationStatusUseCase: any FetchEmailVertificationStatusUseCase { get }
+    var newPasswordFactory: any NewPasswordFactory { get }
 }
 
 public final class FindPasswordComponent: Component<FindPasswordDependency>, FindPasswordFactory {
     public func makeView() -> some View {
         FindPasswordView(
             viewModel: .init(
-                sendEmailCertificationLinkUseCase: dependency.sendEmailCertificationLinkUseCase
-            )
+                sendEmailCertificationLinkUseCase: dependency.sendEmailCertificationLinkUseCase,
+                fetchEmailVertificationStatusUseCase: dependency.fetchEmailVertificationStatusUseCase
+            ),
+            newPasswordFactory: dependency.newPasswordFactory
         )
     }
 }

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
@@ -48,7 +48,7 @@ struct FindPasswordView: View {
                     text: "다음으로",
                     action: {
                         viewModel.updateIsPresentedSendEmailPage(isPresented: true)
-                        //                    viewModel.nextToButtonDidTap()
+                        viewModel.nextToButtonDidTap()
                     }
                 )
                 .disabled(viewModel.isEmailEmpty)
@@ -60,8 +60,7 @@ struct FindPasswordView: View {
                 to: SendEmailView(
                     email: viewModel.email,
                     nextToButtonAction: {
-    //                    viewModel.nextToButtonAction()
-                        viewModel.updateIsPresentedNewPasswordPage(isPresented: true)
+                        viewModel.nextToButtonAction()
                     }
                 ),
                 when: Binding(

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
@@ -45,12 +45,12 @@ struct FindPasswordView: View {
             
             BitgouelButton(
                 text: "다음으로",
-                style: .primary,
                 action: {
                     viewModel.updateIsPresentedSendEmailPage(isPresented: true)
                     viewModel.nextToButtonDidTap()
                 }
             )
+            .disabled(viewModel.isEmailEmpty)
             .padding(.bottom, 20)
         }
         .bitgouelBackButton(dismiss: dismiss)

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
@@ -15,68 +15,71 @@ struct FindPasswordView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading) {
-                BitgouelText(
-                    text: "비밀번호 찾기",
-                    font: .title2
-                )
+        NavigationView {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading) {
+                    BitgouelText(
+                        text: "비밀번호 찾기",
+                        font: .title2
+                    )
+                    
+                    BitgouelText(
+                        text: "이메일 인증을 진행합니다.",
+                        font: .text3
+                    )
+                    .foregroundColor(.bitgouel(.greyscale(.g4)))
+                }
+                .padding(.top, 24)
                 
-                BitgouelText(
-                    text: "이메일 인증을 진행합니다.",
-                    font: .text3
+                BitgouelTextField(
+                    "이메일",
+                    text: Binding(
+                        get: { viewModel.email },
+                        set: { email in
+                            viewModel.updateEmail(email: email)
+                        }
+                    )
                 )
-                .foregroundColor(.bitgouel(.greyscale(.g4)))
+                .padding(.top, 32)
+                
+                Spacer()
+                
+                BitgouelButton(
+                    text: "다음으로",
+                    action: {
+                        viewModel.updateIsPresentedSendEmailPage(isPresented: true)
+                        //                    viewModel.nextToButtonDidTap()
+                    }
+                )
+                .disabled(viewModel.isEmailEmpty)
+                .padding(.bottom, 20)
             }
-            .padding(.top, 24)
-            
-            BitgouelTextField(
-                "이메일",
-                text: Binding(
-                    get: { viewModel.email },
-                    set: { email in
-                        viewModel.updateEmail(email: email)
+            .bitgouelBackButton(dismiss: dismiss)
+            .padding(.horizontal, 28)
+            .navigate(
+                to: SendEmailView(
+                    email: viewModel.email,
+                    nextToButtonAction: {
+    //                    viewModel.nextToButtonAction()
+                        viewModel.updateIsPresentedNewPasswordPage(isPresented: true)
+                    }
+                ),
+                when: Binding(
+                    get: { viewModel.isPresentedSendEmailPage },
+                    set: { isPresented in
+                        viewModel.updateIsPresentedSendEmailPage(isPresented: isPresented)
                     }
                 )
             )
-            .padding(.top, 32)
-            
-            Spacer()
-            
-            BitgouelButton(
-                text: "다음으로",
-                action: {
-                    viewModel.updateIsPresentedSendEmailPage(isPresented: true)
-                    viewModel.nextToButtonDidTap()
-                }
+            .navigate(
+                to: newPasswordFactory.makeView().eraseToAnyView(),
+                when: Binding(
+                    get: { viewModel.isPresentedNewPasswordPage },
+                    set: { isPresented in
+                        viewModel.updateIsPresentedNewPasswordPage(isPresented: isPresented)
+                    }
+                )
             )
-            .disabled(viewModel.isEmailEmpty)
-            .padding(.bottom, 20)
         }
-        .bitgouelBackButton(dismiss: dismiss)
-        .padding(.horizontal, 28)
-        .navigate(
-            to: SendEmailView(
-                email: viewModel.email, 
-                nextToButtonAction: {
-                    viewModel.nextToButtonAction()
-                }
-            ),
-            when: Binding(
-                get: { viewModel.isPresentedSendEmailPage },
-                set: { isPresented in
-                    viewModel.updateIsPresentedSendEmailPage(isPresented: isPresented)
-                }
-            )
-        )
-        .navigate(
-            to: newPasswordFactory.makeView().eraseToAnyView(),
-            when: Binding(
-                get: { viewModel.isPresentedNewPasswordPage },
-                set: { isPresented in
-                    viewModel.updateIsPresentedNewPasswordPage(isPresented: isPresented)
-                }
-            )
-        )
     }
 }

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
@@ -4,8 +4,14 @@ struct FindPasswordView: View {
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: FindPasswordViewModel
 
-    init(viewModel: FindPasswordViewModel) {
+    private let newPasswordFactory: any NewPasswordFactory
+
+    init(
+        viewModel: FindPasswordViewModel,
+        newPasswordFactory: any NewPasswordFactory
+    ) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        self.newPasswordFactory = newPasswordFactory
     }
 
     var body: some View {
@@ -50,11 +56,25 @@ struct FindPasswordView: View {
         .bitgouelBackButton(dismiss: dismiss)
         .padding(.horizontal, 28)
         .navigate(
-            to: SendEmailView(email: viewModel.email),
+            to: SendEmailView(
+                email: viewModel.email, 
+                nextToButtonAction: {
+                    viewModel.nextToButtonAction()
+                }
+            ),
             when: Binding(
                 get: { viewModel.isPresentedSendEmailPage },
                 set: { isPresented in
                     viewModel.updateIsPresentedSendEmailPage(isPresented: isPresented)
+                }
+            )
+        )
+        .navigate(
+            to: newPasswordFactory.makeView().eraseToAnyView(),
+            when: Binding(
+                get: { viewModel.isPresentedNewPasswordPage },
+                set: { isPresented in
+                    viewModel.updateIsPresentedNewPasswordPage(isPresented: isPresented)
                 }
             )
         )

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordViewModel.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordViewModel.swift
@@ -6,6 +6,9 @@ final class FindPasswordViewModel: BaseViewModel {
     @Published var isPresentedSendEmailPage: Bool = false
     @Published var isPresentedNewPasswordPage: Bool = false
     var isAuthentication: Bool = false
+    var isEmailEmpty: Bool {
+        email.isEmpty
+    }
 
     private let sendEmailCertificationLinkUseCase: any SendEmailCertificationLinkUseCase
     private let fetchEmailVertificationStatusUseCase: any FetchEmailVertificationStatusUseCase
@@ -23,7 +26,6 @@ final class FindPasswordViewModel: BaseViewModel {
     }
 
     func updateIsPresentedSendEmailPage(isPresented: Bool) {
-        guard !email.isEmpty else { return }
         isPresentedSendEmailPage = isPresented
     }
 

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordViewModel.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordViewModel.swift
@@ -4,11 +4,18 @@ import Service
 final class FindPasswordViewModel: BaseViewModel {
     @Published var email: String = ""
     @Published var isPresentedSendEmailPage: Bool = false
+    @Published var isPresentedNewPasswordPage: Bool = false
+    var isAuthentication: Bool = false
 
     private let sendEmailCertificationLinkUseCase: any SendEmailCertificationLinkUseCase
+    private let fetchEmailVertificationStatusUseCase: any FetchEmailVertificationStatusUseCase
 
-    init(sendEmailCertificationLinkUseCase: any SendEmailCertificationLinkUseCase) {
+    init(
+        sendEmailCertificationLinkUseCase: any SendEmailCertificationLinkUseCase,
+        fetchEmailVertificationStatusUseCase: any FetchEmailVertificationStatusUseCase
+    ) {
         self.sendEmailCertificationLinkUseCase = sendEmailCertificationLinkUseCase
+        self.fetchEmailVertificationStatusUseCase = fetchEmailVertificationStatusUseCase
     }
 
     func updateEmail(email: String) {
@@ -20,12 +27,29 @@ final class FindPasswordViewModel: BaseViewModel {
         isPresentedSendEmailPage = isPresented
     }
 
+    func updateIsPresentedNewPasswordPage(isPresented: Bool) {
+        isPresentedNewPasswordPage = isPresented
+    }
+
     func nextToButtonDidTap() {
         Task {
             do {
                 try await sendEmailCertificationLinkUseCase(req: EmailRequestDTO(email: email))
             } catch {
                 print(String(describing: error))
+            }
+        }
+    }
+
+    @MainActor
+    func nextToButtonAction() {
+        Task {
+            do {
+                isAuthentication = try await fetchEmailVertificationStatusUseCase(email: email)
+                
+                if isAuthentication { updateIsPresentedNewPasswordPage(isPresented: true) }
+            } catch {
+                print(error.localizedDescription)
             }
         }
     }

--- a/App/Sources/Feature/FindPasswordFeature/Source/View/SendEmailView.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/View/SendEmailView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SendEmailView: View {
     @Environment(\.dismiss) var dismiss
     let email: String
+    let nextToButtonAction: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -16,6 +17,9 @@ struct SendEmailView: View {
                 text: "확인 이메일 발송됨",
                 font: .title2
             )
+            .buttonWrapper {
+                nextToButtonAction()
+            }
         }
         .bitgouelBackButton(dismiss: dismiss)
     }

--- a/App/Sources/Feature/LoginFeature/Sources/LoginView.swift
+++ b/App/Sources/Feature/LoginFeature/Sources/LoginView.swift
@@ -111,6 +111,7 @@ struct LoginView: View {
                     )
                 )
                 .onChange(of: viewModel.isPresentedFindPasswordPage) { newValue in
+                    sceneState.sceneFlow = .findPassword
                     tabbarHidden.wrappedValue = newValue
                 }
             }

--- a/App/Sources/Feature/NewPasswordFeature/Interface/NewPasswordFactory.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Interface/NewPasswordFactory.swift
@@ -1,9 +1,6 @@
-//
-//  NewPasswordFactory.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 3/24/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
+import SwiftUI
 
-import Foundation
+public protocol NewPasswordFactory {
+    associatedtype SomeView: View
+    func makeView() -> SomeView
+}

--- a/App/Sources/Feature/NewPasswordFeature/Interface/NewPasswordFactory.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Interface/NewPasswordFactory.swift
@@ -1,0 +1,9 @@
+//
+//  NewPasswordFactory.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 3/24/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordComponent.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordComponent.swift
@@ -1,0 +1,9 @@
+//
+//  NewPasswordComponent.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 3/24/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordComponent.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordComponent.swift
@@ -6,6 +6,6 @@ public protocol NewPasswordDependency: Dependency {}
 
 public final class NewPasswordComponent: Component<NewPasswordDependency>, NewPasswordFactory {
     public func makeView() -> some View {
-        NewPasswordView()
+        NewPasswordView(viewModel: .init())
     }
 }

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordComponent.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordComponent.swift
@@ -1,9 +1,11 @@
-//
-//  NewPasswordComponent.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 3/24/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
+import NeedleFoundation
+import SwiftUI
+import Service
 
-import Foundation
+public protocol NewPasswordDependency: Dependency {}
+
+public final class NewPasswordComponent: Component<NewPasswordDependency>, NewPasswordFactory {
+    public func makeView() -> some View {
+        NewPasswordView()
+    }
+}

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
@@ -51,12 +51,21 @@ struct NewPasswordView: View {
             BitgouelButton(
                 text: "다음으로",
                 action: {
-                    #warning("비밀번호 찾기 API 연결")
+                    viewModel.updateIsPresentedSuccessFindPasswordPage(isPresented: true)
                 }
             )
             .disabled(viewModel.isPasswordEmpty)
             .padding(.bottom, 20)
         }
         .padding(.horizontal, 28)
+        .navigate(
+            to: SuccessFindPasswordChangeView(),
+            when: Binding(
+                get: { viewModel.isPresentedSuccessFindPasswordPage },
+                set: { isPresented in
+                    viewModel.updateIsPresentedSuccessFindPasswordPage(isPresented: isPresented)
+                }
+            )
+        )
     }
 }

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
@@ -1,9 +1,7 @@
-//
-//  NewPasswordView.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 3/24/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
+import SwiftUI
 
-import Foundation
+struct NewPasswordView: View {
+    var body: some View {
+        Text("Newwwwwww")
+    }
+}

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
@@ -1,0 +1,9 @@
+//
+//  NewPasswordView.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 3/24/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordView.swift
@@ -1,7 +1,62 @@
 import SwiftUI
 
 struct NewPasswordView: View {
+    @StateObject var viewModel: NewPasswordViewModel
+
+    init(viewModel: NewPasswordViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
     var body: some View {
-        Text("Newwwwwww")
+        VStack(alignment: .leading) {
+            VStack(alignment: .leading) {
+                BitgouelText(
+                    text: "비밀번호 변경",
+                    font: .title2
+                )
+                
+                BitgouelText(
+                    text: "새 비밀번호를 설정합니다",
+                    font: .text3
+                )
+                .foregroundColor(.bitgouel(.greyscale(.g4)))
+            }
+            .padding(.top, 24)
+            
+            VStack(alignment: .leading, spacing: 16) {
+                BitgouelTextField(
+                    "8~24자 이내 영문, 숫자, 특수문자 1개 이상",
+                    text: Binding(
+                        get: { viewModel.newPassword },
+                        set: { password in
+                            viewModel.updateNewPassword(password: password)
+                        }
+                    )
+                )
+                
+                BitgouelTextField(
+                    "비밀번호 확인",
+                    text: Binding(
+                        get: { viewModel.checkNewPassword },
+                        set: { password in
+                            viewModel.updateCheckNewPassword(password: password)
+                        }
+                    )
+                )
+            }
+            .padding(.top, 32)
+            
+            Spacer()
+            
+            BitgouelButton(
+                text: "다음으로",
+                action: {
+                    #warning("비밀번호 찾기 API 연결")
+                }
+            )
+            .disabled(viewModel.isPasswordEmpty)
+            .padding(.bottom, 20)
+        }
+        .padding(.horizontal, 28)
     }
 }

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordViewModel.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordViewModel.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class NewPasswordViewModel: BaseViewModel {
+    @Published var newPassword: String = ""
+    @Published var checkNewPassword: String = ""
+    var isPasswordEmpty: Bool {
+        newPassword.isEmpty || checkNewPassword.isEmpty
+    }
+
+    func updateNewPassword(password: String) {
+        newPassword = password
+    }
+
+    func updateCheckNewPassword(password: String) {
+        checkNewPassword = password
+    }
+}

--- a/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordViewModel.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/NewPasswordViewModel.swift
@@ -3,6 +3,8 @@ import Foundation
 final class NewPasswordViewModel: BaseViewModel {
     @Published var newPassword: String = ""
     @Published var checkNewPassword: String = ""
+    @Published var isPresentedSuccessFindPasswordPage: Bool = false
+
     var isPasswordEmpty: Bool {
         newPassword.isEmpty || checkNewPassword.isEmpty
     }
@@ -13,5 +15,9 @@ final class NewPasswordViewModel: BaseViewModel {
 
     func updateCheckNewPassword(password: String) {
         checkNewPassword = password
+    }
+
+    func updateIsPresentedSuccessFindPasswordPage(isPresented: Bool) {
+        isPresentedSuccessFindPasswordPage = isPresented
     }
 }

--- a/App/Sources/Feature/NewPasswordFeature/Source/View/SuccessFindPasswordView.swift
+++ b/App/Sources/Feature/NewPasswordFeature/Source/View/SuccessFindPasswordView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct SuccessFindPasswordChangeView: View {
+    @EnvironmentObject var sceneState: SceneState
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                BitgouelText(
+                    text: "빛고을\n직업교육\n혁신지구",
+                    font: .title1
+                )
+                
+                Spacer()
+            }
+            .padding(.top, 53)
+            
+            Spacer()
+            
+            VStack {
+                BitgouelText(
+                    text: "비밀번호 변경 완료",
+                    font: .title2
+                )
+                
+                BitgouelText(
+                    text: "다시 로그인 해야 합니다",
+                    font: .caption
+                )
+            }
+            
+            Spacer()
+            
+            BitgouelButton(
+                text: "돌아가기",
+                style: .primary
+            ) {
+                sceneState.sceneFlow = .login
+            }
+            .padding(.bottom, 20)
+        }
+        .padding(.horizontal, 28)
+        .navigationBarBackButtonHidden()
+    }
+}

--- a/App/Sources/Feature/RootFeature/RootComponent.swift
+++ b/App/Sources/Feature/RootFeature/RootComponent.swift
@@ -4,13 +4,15 @@ import SwiftUI
 public protocol RootDependency: Dependency {
     var loginFactory: any LoginFactory { get }
     var mainTabFactory: any MainTabFactory { get }
+    var findPasswordFactory: any FindPasswordFactory { get }
 }
 
 public final class RootComponent: Component<RootDependency> {
     public func makeView() -> some View {
         RootView(
             loginFactory: self.dependency.loginFactory,
-            mainTabFactory: self.dependency.mainTabFactory
+            mainTabFactory: self.dependency.mainTabFactory,
+            findPasswordFactory: self.dependency.findPasswordFactory
         )
     }
 }

--- a/App/Sources/Feature/RootFeature/RootView.swift
+++ b/App/Sources/Feature/RootFeature/RootView.swift
@@ -4,13 +4,16 @@ struct RootView: View {
     @EnvironmentObject var sceneState: SceneState
     private let loginFactory: any LoginFactory
     private let mainTabFactory: any MainTabFactory
+    private let findPasswordFactory: any FindPasswordFactory
 
     public init(
         loginFactory: any LoginFactory,
-        mainTabFactory: any MainTabFactory
+        mainTabFactory: any MainTabFactory,
+        findPasswordFactory: any FindPasswordFactory
     ) {
         self.loginFactory = loginFactory
         self.mainTabFactory = mainTabFactory
+        self.findPasswordFactory = findPasswordFactory
     }
 
     var body: some View {
@@ -23,6 +26,11 @@ struct RootView: View {
                 
             case .main:
                 mainTabFactory.makeView()
+                    .eraseToAnyView()
+                    .environmentObject(sceneState)
+                
+            case .findPassword:
+                findPasswordFactory.makeView()
                     .eraseToAnyView()
                     .environmentObject(sceneState)
             }

--- a/Service/Sources/Data/DataSource/Email/RemoteEmailDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/Email/RemoteEmailDataSourceImpl.swift
@@ -5,10 +5,10 @@ public final class RemoteEmailDataSourceImpl: BaseRemoteDataSource<EmailAPI>, Re
         try await request(.sendEmailCertificationLink(req: req))
     }
 
-    public func fetchEmailVerificationStatus(email: String) async throws -> EmailVerificationStatusEntity {
+    public func fetchEmailVerificationStatus(email: String) async throws -> Bool {
         try await request(
             .fetchEmailVerificationStatus(email: email),
             dto: FetchEmailVerificationStatusResponseDTO.self
-        ).toDomain()
+        ).isAuthentication
     }
 }

--- a/Service/Sources/Data/Repository/Email/EmailRepositoryImpl.swift
+++ b/Service/Sources/Data/Repository/Email/EmailRepositoryImpl.swift
@@ -11,7 +11,7 @@ public struct EmailRepositoryImpl: EmailRepository {
         try await remoteEmailDataSource.sendEmailCertificationLink(req: req)
     }
 
-    public func fetchEmailVerificationStatus(email: String) async throws -> EmailVerificationStatusEntity {
+    public func fetchEmailVerificationStatus(email: String) async throws -> Bool {
         try await remoteEmailDataSource.fetchEmailVerificationStatus(email: email)
     }
 }

--- a/Service/Sources/Data/UseCase/Email/FetchEmailVerificationStatusUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/Email/FetchEmailVerificationStatusUseCaseImpl.swift
@@ -7,7 +7,7 @@ public struct FetchEmailVerificationStatusUseCaseImpl: FetchEmailVertificationSt
         self.emailRepository = emailRepository
     }
 
-    public func callAsFunction(email: String) async throws -> EmailVerificationStatusEntity {
+    public func callAsFunction(email: String) async throws -> Bool {
         try await emailRepository.fetchEmailVerificationStatus(email: email)
     }
 }

--- a/Service/Sources/Domain/EmailDomain/DTO/FetchEmailVerificationStatusResponseDTO.swift
+++ b/Service/Sources/Domain/EmailDomain/DTO/FetchEmailVerificationStatusResponseDTO.swift
@@ -7,9 +7,3 @@ public struct FetchEmailVerificationStatusResponseDTO: Decodable {
         self.isAuthentication = isAuthentication
     }
 }
-
-extension FetchEmailVerificationStatusResponseDTO {
-    func toDomain() -> EmailVerificationStatusEntity {
-        EmailVerificationStatusEntity(isAuthentication: isAuthentication)
-    }
-}

--- a/Service/Sources/Domain/EmailDomain/DataSource/RemoteEmailDataSource.swift
+++ b/Service/Sources/Domain/EmailDomain/DataSource/RemoteEmailDataSource.swift
@@ -2,5 +2,5 @@ import Foundation
 
 public protocol RemoteEmailDataSource: BaseRemoteDataSource<EmailAPI> {
     func sendEmailCertificationLink(req: EmailRequestDTO) async throws
-    func fetchEmailVerificationStatus(email: String) async throws -> EmailVerificationStatusEntity
+    func fetchEmailVerificationStatus(email: String) async throws -> Bool
 }

--- a/Service/Sources/Domain/EmailDomain/Entity/EmailVerificationStatusEntity.swift
+++ b/Service/Sources/Domain/EmailDomain/Entity/EmailVerificationStatusEntity.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-public struct EmailVerificationStatusEntity: Equatable {
-    public let isAuthentication: Bool
-
-    public init(isAuthentication: Bool) {
-        self.isAuthentication = isAuthentication
-    }
-}

--- a/Service/Sources/Domain/EmailDomain/Repository/EmailRepository.swift
+++ b/Service/Sources/Domain/EmailDomain/Repository/EmailRepository.swift
@@ -2,5 +2,5 @@ import Foundation
 
 public protocol EmailRepository {
     func sendEmailCertificationLink(req: EmailRequestDTO) async throws
-    func fetchEmailVerificationStatus(email: String) async throws -> EmailVerificationStatusEntity
+    func fetchEmailVerificationStatus(email: String) async throws -> Bool
 }

--- a/Service/Sources/Domain/EmailDomain/UseCase/FetchEmailVertificationStatusUseCase.swift
+++ b/Service/Sources/Domain/EmailDomain/UseCase/FetchEmailVertificationStatusUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol FetchEmailVertificationStatusUseCase {
-    func callAsFunction(email: String) async throws -> EmailVerificationStatusEntity
+    func callAsFunction(email: String) async throws -> Bool
 }


### PR DESCRIPTION
## 💡 개요
비밀번호 찾기 - 이메일 인증 시 비밀번호 변경 페이지를 퍼블리싱 했어요.
## 📃 작업내용

https://github.com/GSM-MSG/Bitgouel-iOS/assets/105629604/1697af89-d1c9-4d1e-b554-a249a0af4263

## 🔀 변경사항
fetchEmailVerificationStatus의 return 값을 EmailVerificationStatusEntity에서 Bool로 변경했어요.
다음으로 버튼에 .disabled(viewModel.isPasswordEmpty)을 추가하여 이메일, 비밀번호를 입력했을 시에만 클릭 가능하도록 변경했어요.

