### PR TITLE
🔀 :: [#262] 메인페이지 - FAQ API 연결

### DIFF
--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -288,15 +288,20 @@ private func factory4545df5fcd42aaf8ed60f47b58f8f304c97af4d5(_ component: Needle
     return InputNoticeDependency7b594803ad882c7e25c9Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class MainDependency7c6a5b4738b211b8e155Provider: MainDependency {
-
-
-    init() {
-
+    var fetchFAQListUseCase: any FetchFAQListUseCase {
+        return appComponent.fetchFAQListUseCase
+    }
+    var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase {
+        return appComponent.loadUserAuthorityUseCase
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
     }
 }
 /// ^->AppComponent->MainComponent
-private func factoryc9274e46e78e70f29c54e3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
-    return MainDependency7c6a5b4738b211b8e155Provider()
+private func factoryc9274e46e78e70f29c54f47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return MainDependency7c6a5b4738b211b8e155Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class RootDependency3944cc797a4a88956fb5Provider: RootDependency {
     var loginFactory: any LoginFactory {
@@ -855,7 +860,8 @@ extension InputNoticeComponent: Registration {
 }
 extension MainComponent: Registration {
     public func registerItems() {
-
+        keyPathToName[\MainDependency.fetchFAQListUseCase] = "fetchFAQListUseCase-any FetchFAQListUseCase"
+        keyPathToName[\MainDependency.loadUserAuthorityUseCase] = "loadUserAuthorityUseCase-any LoadUserAuthorityUseCase"
     }
 }
 extension RootComponent: Registration {
@@ -1178,7 +1184,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->MyPageComponent", factory0f6f456ebf157d02dfb3f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InquiryDetailComponent", factory2d6736bd037393a86ae3f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->InputNoticeComponent", factory4545df5fcd42aaf8ed60f47b58f8f304c97af4d5)
-    registerProviderFactory("^->AppComponent->MainComponent", factoryc9274e46e78e70f29c54e3b0c44298fc1c149afb)
+    registerProviderFactory("^->AppComponent->MainComponent", factoryc9274e46e78e70f29c54f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->RootComponent", factory264bfc4d4cb6b0629b40f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->PostListComponent", factory0c89e2bbcc02dbcac018f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->ChangePasswordComponent", factoryab7c4d87dab53e0a51b9f47b58f8f304c97af4d5)

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -294,6 +294,9 @@ private class MainDependency7c6a5b4738b211b8e155Provider: MainDependency {
     var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase {
         return appComponent.loadUserAuthorityUseCase
     }
+    var inputFAQUseCase: any InputFAQUseCase {
+        return appComponent.inputFAQUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -862,6 +865,7 @@ extension MainComponent: Registration {
     public func registerItems() {
         keyPathToName[\MainDependency.fetchFAQListUseCase] = "fetchFAQListUseCase-any FetchFAQListUseCase"
         keyPathToName[\MainDependency.loadUserAuthorityUseCase] = "loadUserAuthorityUseCase-any LoadUserAuthorityUseCase"
+        keyPathToName[\MainDependency.inputFAQUseCase] = "inputFAQUseCase-any InputFAQUseCase"
     }
 }
 extension RootComponent: Registration {

--- a/App/Sources/Feature/MainFeature/Source/MainComponent.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainComponent.swift
@@ -1,12 +1,19 @@
 import NeedleFoundation
 import SwiftUI
+import Service
 
 public protocol MainDependency: Dependency {
-    
+    var fetchFAQListUseCase: any FetchFAQListUseCase { get }
+    var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase { get }
 }
 
 public final class MainComponent: Component<MainDependency>, MainFactory {
     public func makeView() -> some View {
-        MainView()
+        MainView(
+            viewModel: .init(
+                fetchFAQListUseCase: dependency.fetchFAQListUseCase,
+                loadUserAuthorityUseCase: dependency.loadUserAuthorityUseCase
+            )
+        )
     }
 }

--- a/App/Sources/Feature/MainFeature/Source/MainComponent.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainComponent.swift
@@ -5,6 +5,7 @@ import Service
 public protocol MainDependency: Dependency {
     var fetchFAQListUseCase: any FetchFAQListUseCase { get }
     var loadUserAuthorityUseCase: any LoadUserAuthorityUseCase { get }
+    var inputFAQUseCase: any InputFAQUseCase { get }
 }
 
 public final class MainComponent: Component<MainDependency>, MainFactory {
@@ -12,7 +13,8 @@ public final class MainComponent: Component<MainDependency>, MainFactory {
         MainView(
             viewModel: .init(
                 fetchFAQListUseCase: dependency.fetchFAQListUseCase,
-                loadUserAuthorityUseCase: dependency.loadUserAuthorityUseCase
+                loadUserAuthorityUseCase: dependency.loadUserAuthorityUseCase,
+                inputFAQUseCase: dependency.inputFAQUseCase
             )
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/MainView.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainView.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 struct MainView: View {
+    @StateObject var viewModel: MainViewModel
+
+    init(viewModel: MainViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+    
     var body: some View {
         ScrollView(showsIndicators: false) {
             Image("mainpage_image_1")
@@ -8,7 +14,6 @@ struct MainView: View {
                 .padding(.bottom, 16)
             
             VStack(spacing: 64) {
-                
                 VStack(spacing: 64) {
                     BitgouelPromotionView()
                     
@@ -61,10 +66,13 @@ struct MainView: View {
                 
                 GovernmentView()
                 
-                FAQView(faqList: .init())
+                FAQView(faqList: viewModel.faqList)
                     .padding(.horizontal, 28)
                     .padding(.bottom, 40)
             }
+        }
+        .onAppear {
+            viewModel.onAppear()
         }
     }
 }

--- a/App/Sources/Feature/MainFeature/Source/MainView.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainView.swift
@@ -72,18 +72,20 @@ struct MainView: View {
                         authority: viewModel.authority
                     )
                     
-                    InputFAQView(
-                        addFAQButtonDidTap: Binding(
-                            get: { viewModel.inputFAQButtonDidTap },
-                            set: { state in
-                                viewModel.updateInputFAQButtonDidTap(state: state)
+                    if viewModel.authority == .admin {
+                        InputFAQView(
+                            addFAQButtonDidTap: Binding(
+                                get: { viewModel.inputFAQButtonDidTap },
+                                set: { state in
+                                    viewModel.updateInputFAQButtonDidTap(state: state)
+                                }
+                            ),
+                            inputFAQAction: { question,answer in
+                                viewModel.updateFAQ(question: question, answer: answer)
+                                viewModel.inputFAQ()
                             }
-                        ),
-                        inputFAQAction: { question,answer in
-                            viewModel.updateFAQ(question: question, answer: answer)
-                            viewModel.inputFAQ()
-                        }
-                    )
+                        )
+                    }
                 }
                 .padding(.horizontal, 28)
                 .padding(.bottom, 40)

--- a/App/Sources/Feature/MainFeature/Source/MainView.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct MainView: View {
     @StateObject var viewModel: MainViewModel
-
+    
     init(viewModel: MainViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
@@ -66,9 +66,25 @@ struct MainView: View {
                 
                 GovernmentView()
                 
-                FAQView(faqList: viewModel.faqList)
-                    .padding(.horizontal, 28)
-                    .padding(.bottom, 40)
+                FAQView(
+                    faqList: viewModel.faqList,
+                    authority: viewModel.authority
+                )
+                .padding(.horizontal, 28)
+                
+                InputFAQView(
+                    addFAQButtonDidTap: Binding(
+                        get: { viewModel.inputFAQButtonDidTap },
+                        set: { state in
+                            viewModel.updateInputFAQButtonDidTap(state: state)
+                        }
+                    ),
+                    inputFAQAction: { question,answer in 
+                        viewModel.updateFAQ(question: question, answer: answer)
+                    }
+                )
+                .padding(.horizontal, 28)
+                .padding(.bottom, 40)
             }
         }
         .onAppear {

--- a/App/Sources/Feature/MainFeature/Source/MainView.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainView.swift
@@ -66,23 +66,25 @@ struct MainView: View {
                 
                 GovernmentView()
                 
-                FAQView(
-                    faqList: viewModel.faqList,
-                    authority: viewModel.authority
-                )
-                .padding(.horizontal, 28)
-                
-                InputFAQView(
-                    addFAQButtonDidTap: Binding(
-                        get: { viewModel.inputFAQButtonDidTap },
-                        set: { state in
-                            viewModel.updateInputFAQButtonDidTap(state: state)
+                VStack(spacing: 16) {
+                    FAQView(
+                        faqList: viewModel.faqList,
+                        authority: viewModel.authority
+                    )
+                    
+                    InputFAQView(
+                        addFAQButtonDidTap: Binding(
+                            get: { viewModel.inputFAQButtonDidTap },
+                            set: { state in
+                                viewModel.updateInputFAQButtonDidTap(state: state)
+                            }
+                        ),
+                        inputFAQAction: { question,answer in
+                            viewModel.updateFAQ(question: question, answer: answer)
+                            viewModel.inputFAQ()
                         }
-                    ),
-                    inputFAQAction: { question,answer in 
-                        viewModel.updateFAQ(question: question, answer: answer)
-                    }
-                )
+                    )
+                }
                 .padding(.horizontal, 28)
                 .padding(.bottom, 40)
             }

--- a/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
@@ -3,7 +3,10 @@ import Service
 
 final class MainViewModel: BaseViewModel {
     @Published var faqList: [FAQInfoEntity] = []
-    var authority: UserAuthorityType = .user
+    @Published var authority: UserAuthorityType = .user
+    @Published var question: String = ""
+    @Published var answer: String = ""
+    @Published var inputFAQButtonDidTap: Bool = false
 
     private let fetchFAQListUseCase: any FetchFAQListUseCase
     private let loadUserAuthorityUseCase: any LoadUserAuthorityUseCase
@@ -14,6 +17,15 @@ final class MainViewModel: BaseViewModel {
     ) {
         self.fetchFAQListUseCase = fetchFAQListUseCase
         self.loadUserAuthorityUseCase = loadUserAuthorityUseCase
+    }
+
+    func updateFAQ(question: String, answer: String) {
+        self.question = question
+        self.answer = answer
+    }
+
+    func updateInputFAQButtonDidTap(state: Bool) {
+        inputFAQButtonDidTap = state
     }
 
     @MainActor

--- a/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Service
+
+final class MainViewModel: BaseViewModel {
+    @Published var faqList: [FAQInfoEntity] = []
+    var authority: UserAuthorityType = .user
+
+    private let fetchFAQListUseCase: any FetchFAQListUseCase
+    private let loadUserAuthorityUseCase: any LoadUserAuthorityUseCase
+
+    init(
+        fetchFAQListUseCase: any FetchFAQListUseCase,
+        loadUserAuthorityUseCase: any LoadUserAuthorityUseCase
+    ) {
+        self.fetchFAQListUseCase = fetchFAQListUseCase
+        self.loadUserAuthorityUseCase = loadUserAuthorityUseCase
+    }
+
+    @MainActor
+    func onAppear() {
+        authority = loadUserAuthorityUseCase()
+
+        Task {
+            do {
+                faqList = try await fetchFAQListUseCase()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
@@ -10,13 +10,16 @@ final class MainViewModel: BaseViewModel {
 
     private let fetchFAQListUseCase: any FetchFAQListUseCase
     private let loadUserAuthorityUseCase: any LoadUserAuthorityUseCase
+    private let inputFAQUseCase: any InputFAQUseCase
 
     init(
         fetchFAQListUseCase: any FetchFAQListUseCase,
-        loadUserAuthorityUseCase: any LoadUserAuthorityUseCase
+        loadUserAuthorityUseCase: any LoadUserAuthorityUseCase,
+        inputFAQUseCase: any InputFAQUseCase
     ) {
         self.fetchFAQListUseCase = fetchFAQListUseCase
         self.loadUserAuthorityUseCase = loadUserAuthorityUseCase
+        self.inputFAQUseCase = inputFAQUseCase
     }
 
     func updateFAQ(question: String, answer: String) {
@@ -35,6 +38,19 @@ final class MainViewModel: BaseViewModel {
         Task {
             do {
                 faqList = try await fetchFAQListUseCase()
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
+    @MainActor
+    func inputFAQ() {
+        Task {
+            do {
+                try await inputFAQUseCase(req: InputFAQRequestDTO(question: question, answer: answer))
+                
+                updateInputFAQButtonDidTap(state: false)
             } catch {
                 print(error.localizedDescription)
             }

--- a/App/Sources/Feature/MainFeature/Source/View/FAQView.swift
+++ b/App/Sources/Feature/MainFeature/Source/View/FAQView.swift
@@ -2,7 +2,11 @@ import SwiftUI
 import Service
 
 struct FAQView: View {
+    @State var question: String = ""
+    @State var answer: String = ""
+    
     var faqList: [FAQInfoEntity]
+    let authority: UserAuthorityType
 
     var body: some View {
         VStack(spacing: 24) {
@@ -28,7 +32,7 @@ struct FAQView: View {
         answer: String
     ) -> some View {
         VStack(spacing: 12) {
-            HStack(spacing: 0) {
+            HStack(spacing: 4) {
                 Text("Q.")
                     .bitgouelFont(.text3, color: .primary(.p5))
                 
@@ -41,7 +45,7 @@ struct FAQView: View {
             if !answer.isEmpty {
                 Divider()
                 
-                HStack(spacing: 0) {
+                HStack(spacing: 4) {
                     Text("A.")
                         .bitgouelFont(.text3, color: .primary(.p5))
                     

--- a/App/Sources/Feature/MainFeature/Source/View/FAQView.swift
+++ b/App/Sources/Feature/MainFeature/Source/View/FAQView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import Service
 
 struct FAQView: View {
-    let faqList: [FAQInfoEntity]
-    
+    var faqList: [FAQInfoEntity]
+
     var body: some View {
         VStack(spacing: 24) {
             IntroduceView(
@@ -21,7 +21,7 @@ struct FAQView: View {
             }
         }
     }
-    
+
     @ViewBuilder
     func faqRow(
         question: String,

--- a/App/Sources/Feature/MainFeature/Source/View/InputFAQView.swift
+++ b/App/Sources/Feature/MainFeature/Source/View/InputFAQView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct InputFAQView: View {
+    @State var question: String = ""
+    @State var answer: String = ""
+    @Binding var addFAQButtonDidTap: Bool
+    var inputFAQAction: (_ question: String, _ answer: String) -> Void
+    
+    var body: some View {
+        VStack {
+            if !addFAQButtonDidTap {
+                HStack {
+                    BitgouelAsset.Icons.add.swiftUIImage
+                        .renderingMode(.template)
+                        .frame(width: 10, height: 10)
+                        .foregroundColor(.bitgouel(.primary(.p5)))
+                    
+                    BitgouelText(
+                        text: "자주 묻는 질문 추가하기",
+                        font: .text3
+                    )
+                    .padding(.leading, 8)
+                    .foregroundColor(.bitgouel(.primary(.p5)))
+                    
+                    Spacer()
+                }
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundColor(.white)
+                        .shadow(color: .gray, radius: 1, x: 1, y: 1)
+                        .opacity(0.3)
+                )
+                .buttonWrapper {
+                    addFAQButtonDidTap = true
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(spacing: 4) {
+                        Text("Q.")
+                            .bitgouelFont(.text3, color: .primary(.p5))
+                        
+                        TextEditor(
+                            text: Binding(
+                                get: { question },
+                                set: { newQuestion in
+                                    question = newQuestion
+                                }
+                            )
+                        )
+                        .overlay {
+                            if question.isEmpty {
+                                HStack {
+                                    Text("질문 작성하기")
+                                        .bitgouelFont(.text3, color: .greyscale(.g7))
+                                        .padding(.leading, 4)
+                                    
+                                    Spacer()
+                                }
+                            }
+                        }
+                    }
+                    
+                    Divider()
+                        .background(Color.bitgouel(.greyscale(.g0)))
+                    
+                    HStack(spacing: 4) {
+                        Text("A.")
+                            .bitgouelFont(.text3, color: .primary(.p5))
+                        
+                        TextEditor(
+                            text: Binding(
+                                get: { answer },
+                                set: { newAnswer in
+                                    answer = newAnswer
+                                }
+                            )
+                        )
+                        .overlay {
+                            if answer.isEmpty {
+                                HStack {
+                                    Text("답변 작성하기")
+                                        .bitgouelFont(.text3, color: .greyscale(.g7))
+                                        .padding(.leading, 4)
+                                    
+                                    Spacer()
+                                }
+                            }
+                        }
+                    }
+                    
+                    Divider()
+                        .background(Color.bitgouel(.greyscale(.g0)))
+                    
+                    HStack(spacing: 24) {
+                        Spacer()
+                        
+                        Button {
+                            addFAQButtonDidTap = false
+                            question = ""
+                            answer = ""
+                        } label: {
+                            Text("취소")
+                                .bitgouelFont(.text3, color: .greyscale(.g7))
+                        }
+                        
+                        Button {
+                            inputFAQAction(question, answer)
+                        } label: {
+                            Text("작성")
+                                .bitgouelFont(.text3, color: .primary(.p5))
+                        }
+                    }
+                }
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundColor(.white)
+                        .shadow(color: .gray, radius: 1, x: 1, y: 1)
+                        .opacity(0.3)
+                )
+            }
+        }
+    }
+}

--- a/Service/Sources/Domain/FAQDomain/DTO/Response/FetchFAQListResponseDTO.swift
+++ b/Service/Sources/Domain/FAQDomain/DTO/Response/FetchFAQListResponseDTO.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 public struct FetchFAQListResponseDTO: Decodable {
-    public let faqList: [FAQInfo]
+    public let faqs: [FAQInfo]
 
-    public init(faqList: [FAQInfo]) {
-        self.faqList = faqList
+    public init(faqs: [FAQInfo]) {
+        self.faqs = faqs
     }
 
     public struct FAQInfo: Decodable {
-        public let questionID: String
+        public let questionID: Int
         public let question: String
         public let answer: String
 
         public init(
-            questionID: String,
+            questionID: Int,
             question: String,
             answer: String
         ) {
@@ -32,7 +32,7 @@ public struct FetchFAQListResponseDTO: Decodable {
 
 extension FetchFAQListResponseDTO {
     func toDomain() -> [FAQInfoEntity] {
-        faqList.map { $0.toDomain() }
+        faqs.map { $0.toDomain() }
     }
 }
 

--- a/Service/Sources/Domain/FAQDomain/Entity/FAQInfoEntity.swift
+++ b/Service/Sources/Domain/FAQDomain/Entity/FAQInfoEntity.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public struct FAQInfoEntity: Equatable {
-    public let questionID: String
+    public let questionID: Int
     public let question: String
     public let answer: String
 
     public init(
-        questionID: String,
+        questionID: Int,
         question: String,
         answer: String
     ) {


### PR DESCRIPTION
## 💡 개요
메인페이지에 FAQ부분에 API를 연결했어요.

## 📃 작업내용
FAQ리스트 조회 기능을 추가했어요.
자주 묻는 질문을 추가하는 기능을 추가했어요.
자주 묻는 질문을 추가하는 버튼, 추가 Row를 제작했어요.

## 🔀 변경사항
fetchFAQListResponseDTO에 response값이 faqList에서 faqs로 변경되었어요.
FAQInfoEntity에 questionID가 String에서 Int로 타입이 변환되었어요.
