### PR TITLE
🔀 :: [#270] dismiss Action 추가

### DIFF
--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct FindPasswordView: View {
     @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var sceneState: SceneState
     @StateObject var viewModel: FindPasswordViewModel
 
     private let newPasswordFactory: any NewPasswordFactory
@@ -54,7 +55,9 @@ struct FindPasswordView: View {
                 .disabled(viewModel.isEmailEmpty)
                 .padding(.bottom, 20)
             }
-            .bitgouelBackButton(dismiss: dismiss)
+            .bitgouelBackButton(dismiss: dismiss) {
+                sceneState.sceneFlow = .login
+            }
             .padding(.horizontal, 28)
             .navigate(
                 to: SendEmailView(
@@ -79,6 +82,9 @@ struct FindPasswordView: View {
                     }
                 )
             )
+        }
+        .onTapGesture {
+            hideKeyboard()
         }
     }
 }


### PR DESCRIPTION
## 💡 개요
비밀번호 찾기 페이지로 이동 후 돌아가기 버튼을 누르면 로그인 페이지로 이동하지 않던 문제가 있었어요.

## 📃 작업내용
backButton에 dismiss Action을 추가해줬어요.

## 🔀 변경사항
화면 선택시 키보드가 사라지도록 수정했어요.