### PR TITLE
🔀 :: [#272] ButtonPadding 수정

### DIFF
--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
@@ -22,7 +22,7 @@ struct AdminRequestUserSignupView: View {
                 HStack(spacing: 10) {
                     optionButton(
                         buttonText: "전체 선택",
-                        foregroundColor: .bitgouel(.greyscale(.g6))
+                        foregroundColor: .bitgouel(.greyscale(.g4))
                     ) {
                         if viewModel.isSelectedUserList {
                             viewModel.removeAllUserList()
@@ -172,8 +172,8 @@ struct AdminRequestUserSignupView: View {
             font: .text3
         )
         .foregroundColor(foregroundColor)
-        .padding(.horizontal, 23)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 9)
         .overlay {
             RoundedRectangle(cornerRadius: 8)
                 .strokeBorder(foregroundColor)

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
@@ -52,12 +52,12 @@ struct AdminWithdrawUserListView: View {
                             font: .text3
                         )
                     }
-                    .foregroundColor(.bitgouel(.greyscale(.g6)))
-                    .padding(.horizontal, 23)
-                    .padding(.vertical, 12)
+                    .foregroundColor(.bitgouel(.greyscale(.g4)))
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 9)
                     .overlay {
                         RoundedRectangle(cornerRadius: 8)
-                            .strokeBorder(Color.bitgouel(.greyscale(.g6)))
+                            .strokeBorder(Color.bitgouel(.greyscale(.g4)))
                     }
                     .onTapGesture {
                         viewModel.isPresentedUserCohortFilter = true
@@ -190,8 +190,8 @@ struct AdminWithdrawUserListView: View {
             font: .text3
         )
         .foregroundColor(textColor)
-        .padding(.horizontal, 23)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 9)
         .overlay {
             RoundedRectangle(cornerRadius: 8)
                 .strokeBorder(strokeColor)


### PR DESCRIPTION
## 💡 개요
탈퇴예정자명단 페이지에 있는 필터 버튼, 가입요청자명단 페이지에 있는 전체 선택 버튼의 Text가 두 줄로 나오는 문제가 있었어요.

## 📃 작업내용
디자인보다 horizontal, vertical padding이 더 많이 들어가 있어서 알맞게 수정했어요.