### PR TITLE
🔀 :: [#291] 강의 이수 중인 학생 전체 조회, 강의 이수 여부 수정 기능 추가

### DIFF
--- a/App/Sources/Application/DI/Lecture/AppComponent+Lecture.swift
+++ b/App/Sources/Application/DI/Lecture/AppComponent+Lecture.swift
@@ -73,4 +73,10 @@ public extension AppComponent {
             FetchAppliedLectureListUseCaseImpl(lectureRepository: lectureRepository)
         }
     }
+
+    var fetchApplicantListUseCase: any FetchApplicantListUseCase {
+        shared {
+            FetchApplicantListUseCaseImpl(lectureRepository: lectureRepository)
+        }
+    }
 }

--- a/App/Sources/Application/DI/Lecture/AppComponent+Lecture.swift
+++ b/App/Sources/Application/DI/Lecture/AppComponent+Lecture.swift
@@ -79,4 +79,10 @@ public extension AppComponent {
             FetchApplicantListUseCaseImpl(lectureRepository: lectureRepository)
         }
     }
+
+    var modifyApplicantWhetherUseCase: any ModifyApplicantWhetherUseCase {
+        shared {
+            ModifyApplicantWhetherUseCaseImpl(lectureRepository: lectureRepository)
+        }
+    }
 }

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -492,6 +492,9 @@ private class LectureApplicantListDependency5bfdb7310dde792c0738Provider: Lectur
     var fetchApplicantListUseCase: any FetchApplicantListUseCase {
         return appComponent.fetchApplicantListUseCase
     }
+    var modifyApplicantWhetherUseCase: any ModifyApplicantWhetherUseCase {
+        return appComponent.modifyApplicantWhetherUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -993,6 +996,7 @@ extension AdminRequestUserSignupComponent: Registration {
 extension LectureApplicantListComponent: Registration {
     public func registerItems() {
         keyPathToName[\LectureApplicantListDependency.fetchApplicantListUseCase] = "fetchApplicantListUseCase-any FetchApplicantListUseCase"
+        keyPathToName[\LectureApplicantListDependency.modifyApplicantWhetherUseCase] = "modifyApplicantWhetherUseCase-any ModifyApplicantWhetherUseCase"
     }
 }
 extension StudentInfoComponent: Registration {

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -1128,6 +1128,7 @@ extension AppComponent: Registration {
         localTable["fetchDivisionListUseCase-any FetchDivisionListUseCase"] = { [unowned self] in self.fetchDivisionListUseCase as Any }
         localTable["fetchAppliedLectureListUseCase-any FetchAppliedLectureListUseCase"] = { [unowned self] in self.fetchAppliedLectureListUseCase as Any }
         localTable["fetchApplicantListUseCase-any FetchApplicantListUseCase"] = { [unowned self] in self.fetchApplicantListUseCase as Any }
+        localTable["modifyApplicantWhetherUseCase-any ModifyApplicantWhetherUseCase"] = { [unowned self] in self.modifyApplicantWhetherUseCase as Any }
         localTable["remoteClubDataSource-any RemoteClubDataSource"] = { [unowned self] in self.remoteClubDataSource as Any }
         localTable["clubRepository-any ClubRepository"] = { [unowned self] in self.clubRepository as Any }
         localTable["queryClubListUseCase-any QueryClubListUseCase"] = { [unowned self] in self.queryClubListUseCase as Any }

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -1125,6 +1125,7 @@ extension AppComponent: Registration {
         localTable["fetchDepartmentListUseCase-any FetchDepartmentListUseCase"] = { [unowned self] in self.fetchDepartmentListUseCase as Any }
         localTable["fetchDivisionListUseCase-any FetchDivisionListUseCase"] = { [unowned self] in self.fetchDivisionListUseCase as Any }
         localTable["fetchAppliedLectureListUseCase-any FetchAppliedLectureListUseCase"] = { [unowned self] in self.fetchAppliedLectureListUseCase as Any }
+        localTable["fetchApplicantListUseCase-any FetchApplicantListUseCase"] = { [unowned self] in self.fetchApplicantListUseCase as Any }
         localTable["remoteClubDataSource-any RemoteClubDataSource"] = { [unowned self] in self.remoteClubDataSource as Any }
         localTable["clubRepository-any ClubRepository"] = { [unowned self] in self.clubRepository as Any }
         localTable["queryClubListUseCase-any QueryClubListUseCase"] = { [unowned self] in self.queryClubListUseCase as Any }

--- a/App/Sources/Application/NeedleGenerated.swift
+++ b/App/Sources/Application/NeedleGenerated.swift
@@ -489,15 +489,17 @@ private func factory2c6c6f3f10221ceac3a8f47b58f8f304c97af4d5(_ component: Needle
     return AdminRequestUserSignupDependency260e3843e854d6971798Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class LectureApplicantListDependency5bfdb7310dde792c0738Provider: LectureApplicantListDependency {
-
-
-    init() {
-
+    var fetchApplicantListUseCase: any FetchApplicantListUseCase {
+        return appComponent.fetchApplicantListUseCase
+    }
+    private let appComponent: AppComponent
+    init(appComponent: AppComponent) {
+        self.appComponent = appComponent
     }
 }
 /// ^->AppComponent->LectureApplicantListComponent
-private func factory78a87c10d14f7bbaaa9de3b0c44298fc1c149afb(_ component: NeedleFoundation.Scope) -> AnyObject {
-    return LectureApplicantListDependency5bfdb7310dde792c0738Provider()
+private func factory78a87c10d14f7bbaaa9df47b58f8f304c97af4d5(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return LectureApplicantListDependency5bfdb7310dde792c0738Provider(appComponent: parent1(component) as! AppComponent)
 }
 private class StudentInfoDependency5d1163a5288c79c06dffProvider: StudentInfoDependency {
     var activityListFactory: any ActivityListFactory {
@@ -990,7 +992,7 @@ extension AdminRequestUserSignupComponent: Registration {
 }
 extension LectureApplicantListComponent: Registration {
     public func registerItems() {
-
+        keyPathToName[\LectureApplicantListDependency.fetchApplicantListUseCase] = "fetchApplicantListUseCase-any FetchApplicantListUseCase"
     }
 }
 extension StudentInfoComponent: Registration {
@@ -1276,7 +1278,7 @@ private func registerProviderFactory(_ componentPath: String, _ factory: @escapi
     registerProviderFactory("^->AppComponent->SuccessSignUpComponent", factorybf219b153b668170161df47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->FindPasswordComponent", factory15775d8436b06b9741d1f47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->AdminRequestUserSignupComponent", factory2c6c6f3f10221ceac3a8f47b58f8f304c97af4d5)
-    registerProviderFactory("^->AppComponent->LectureApplicantListComponent", factory78a87c10d14f7bbaaa9de3b0c44298fc1c149afb)
+    registerProviderFactory("^->AppComponent->LectureApplicantListComponent", factory78a87c10d14f7bbaaa9df47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->StudentInfoComponent", factory5ce0f173abbf535f654ff47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->AdminWithdrawUserListComponent", factory1ef284da45544ee52e3ef47b58f8f304c97af4d5)
     registerProviderFactory("^->AppComponent->WriteInquiryAnswerComponent", factory3d4cadf14cd9a3336981f47b58f8f304c97af4d5)

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/Component/LectureApplicantListRow.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/Component/LectureApplicantListRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct LectureApplicantListRow: View {
     let studentID: String
+    @State var selectedStudentID: String
     let email: String
     let name: String
     let grade: Int
@@ -11,26 +12,23 @@ struct LectureApplicantListRow: View {
     let phoneNumber: String
     let schoolName: String
     let clubName: String
-    @State var isSelected: Bool = false
-    let checkStudent: (String) -> Void
     
     var body: some View {
         HStack(alignment: .top, spacing: 24) {
             CheckButton(
                 isSelected: Binding(
-                    get: { isSelected },
-                    set: { selected in
-                        if selected {
-                            isSelected = selected
-                            checkStudent(studentID)
+                    get: { studentID == selectedStudentID },
+                    set: { isSelected in
+                        if isSelected {
+                            selectedStudentID = studentID
                         } else {
-                            isSelected = selected
+                            selectedStudentID = ""
                         }
                     }
                 )
             )
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 8) {
                 BitgouelText(
                     text: "\(grade)학년 \(classNumber)반 \(number)번 \(cohort)기 \(name)",
                     font: .text1

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/Component/LectureApplicantListRow.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/Component/LectureApplicantListRow.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct LectureApplicantListRow: View {
     let studentID: String
-    @State var selectedStudentID: String
+    @State var isComplete: Bool
     let email: String
     let name: String
     let grade: Int
@@ -12,17 +12,20 @@ struct LectureApplicantListRow: View {
     let phoneNumber: String
     let schoolName: String
     let clubName: String
+    let onSelectedStudent: (Bool, String) -> Void
     
     var body: some View {
         HStack(alignment: .top, spacing: 24) {
             CheckButton(
                 isSelected: Binding(
-                    get: { studentID == selectedStudentID },
+                    get: { isComplete },
                     set: { isSelected in
                         if isSelected {
-                            selectedStudentID = studentID
+                            isComplete = isSelected
+                            onSelectedStudent(isSelected, studentID)
                         } else {
-                            selectedStudentID = ""
+                            isComplete = isSelected
+                            onSelectedStudent(isSelected, studentID)
                         }
                     }
                 )

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListComponent.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListComponent.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 public protocol LectureApplicantListDependency: Dependency {
     var fetchApplicantListUseCase: any FetchApplicantListUseCase { get }
+    var modifyApplicantWhetherUseCase: any ModifyApplicantWhetherUseCase { get }
 }
 
 public final class LectureApplicantListComponent: Component<LectureApplicantListDependency>,
@@ -12,7 +13,8 @@ public final class LectureApplicantListComponent: Component<LectureApplicantList
         LectureApplicantListView(
             viewModel: LectureApplicantListViewModel(
                 lectureID: lectureID,
-                fetchApplicantListUseCase: dependency.fetchApplicantListUseCase
+                fetchApplicantListUseCase: dependency.fetchApplicantListUseCase,
+                modifyApplicantWhetherUseCase: dependency.modifyApplicantWhetherUseCase
             )
         )
     }

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListComponent.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListComponent.swift
@@ -2,11 +2,18 @@ import NeedleFoundation
 import Service
 import SwiftUI
 
-public protocol LectureApplicantListDependency: Dependency {}
+public protocol LectureApplicantListDependency: Dependency {
+    var fetchApplicantListUseCase: any FetchApplicantListUseCase { get }
+}
 
 public final class LectureApplicantListComponent: Component<LectureApplicantListDependency>,
     LectureApplicantListFactory {
     public func makeView(lectureID: String) -> some View {
-        LectureApplicantListView()
+        LectureApplicantListView(
+            viewModel: LectureApplicantListViewModel(
+                lectureID: lectureID,
+                fetchApplicantListUseCase: dependency.fetchApplicantListUseCase
+            )
+        )
     }
 }

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
@@ -17,8 +17,8 @@ struct LectureApplicantListView: View {
                 LazyVStack(alignment: .leading, spacing: 12) {
                     ForEach(viewModel.applicantList, id: \.studentID) { student in
                         LectureApplicantListRow(
-                            studentID: student.studentID, 
-                            selectedStudentID: viewModel.selectedStudentID,
+                            studentID: student.studentID,
+                            isComplete: student.isComplete, 
                             email: student.email,
                             name: student.name,
                             grade: student.grade,
@@ -27,8 +27,10 @@ struct LectureApplicantListView: View {
                             cohort: student.cohort,
                             phoneNumber: student.phoneNumber,
                             schoolName: student.school.display(),
-                            clubName: student.clubName
-                        )
+                            clubName: student.clubName) { isSelected, studentID in
+                                viewModel.updateApplicantInfo(isSelected: isSelected, studentID: studentID)
+                                viewModel.modifyApplicantWhether()
+                            }
 
                         Divider()
                     }
@@ -40,6 +42,9 @@ struct LectureApplicantListView: View {
         }
         .padding(.horizontal, 28)
         .onAppear {
+            viewModel.onAppear()
+        }
+        .refreshable {
             viewModel.onAppear()
         }
         .navigationTitle("강의 신청자 명단")

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 struct LectureApplicantListView: View {
+    @StateObject var viewModel: LectureApplicantListViewModel
+
+    init(viewModel: LectureApplicantListViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("강의 이수 여부")
@@ -9,20 +15,20 @@ struct LectureApplicantListView: View {
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 12) {
-                    ForEach(1..<4, id: \.self) { id in
+                    ForEach(viewModel.applicantList, id: \.studentID) { student in
                         LectureApplicantListRow(
-                            studentID: "\(id)",
-                            email: "hey@gmail.com",
-                            name: "딩가딩가",
-                            grade: 1,
-                            classNumber: 2,
-                            number: 12,
-                            cohort: 5,
-                            phoneNumber: "010-1234-5678",
-                            schoolName: "딩가딩가학교",
-                            clubName: "딩가딩가딩") { checkStudentID in
-                                print(checkStudentID)
-                            }
+                            studentID: student.studentID, 
+                            selectedStudentID: viewModel.selectedStudentID,
+                            email: student.email,
+                            name: student.name,
+                            grade: student.grade,
+                            classNumber: student.classNumber,
+                            number: student.number,
+                            cohort: student.cohort,
+                            phoneNumber: student.phoneNumber,
+                            schoolName: student.school.display(),
+                            clubName: student.clubName
+                        )
 
                         Divider()
                     }
@@ -33,6 +39,9 @@ struct LectureApplicantListView: View {
             Spacer()
         }
         .padding(.horizontal, 28)
+        .onAppear {
+            viewModel.onAppear()
+        }
         .navigationTitle("강의 신청자 명단")
     }
 }

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
@@ -4,16 +4,25 @@ import Service
 final class LectureApplicantListViewModel: BaseViewModel {
     @Published var applicantList: [ApplicantInfoEntity] = []
     @Published var selectedStudentID: String = ""
+    @Published var isComplete: Bool = false
     var lectureID: String = ""
 
     private let fetchApplicantListUseCase: any FetchApplicantListUseCase
+    private let modifyApplicantWhetherUseCase: any ModifyApplicantWhetherUseCase
     
     init(
         lectureID: String,
-        fetchApplicantListUseCase: any FetchApplicantListUseCase
+        fetchApplicantListUseCase: any FetchApplicantListUseCase,
+        modifyApplicantWhetherUseCase: any ModifyApplicantWhetherUseCase
     ) {
         self.lectureID = lectureID
         self.fetchApplicantListUseCase = fetchApplicantListUseCase
+        self.modifyApplicantWhetherUseCase = modifyApplicantWhetherUseCase
+    }
+
+    func updateApplicantInfo(isSelected: Bool, studentID: String) {
+        isComplete = isSelected
+        selectedStudentID = studentID
     }
 
     @MainActor
@@ -21,6 +30,16 @@ final class LectureApplicantListViewModel: BaseViewModel {
         Task {
             do {
                 applicantList = try await fetchApplicantListUseCase(lectureID: lectureID)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
+    func modifyApplicantWhether() {
+        Task {
+            do {
+                try await modifyApplicantWhetherUseCase(lectureID: lectureID, studentID: selectedStudentID, isComplete: isComplete)
             } catch {
                 print(error.localizedDescription)
             }

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  LectureApplicantListViewModel.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 4/30/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
@@ -1,9 +1,29 @@
-//
-//  LectureApplicantListViewModel.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 4/30/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
-
 import Foundation
+import Service
+
+final class LectureApplicantListViewModel: BaseViewModel {
+    @Published var applicantList: [ApplicantInfoEntity] = []
+    @Published var selectedStudentID: String = ""
+    var lectureID: String = ""
+
+    private let fetchApplicantListUseCase: any FetchApplicantListUseCase
+    
+    init(
+        lectureID: String,
+        fetchApplicantListUseCase: any FetchApplicantListUseCase
+    ) {
+        self.lectureID = lectureID
+        self.fetchApplicantListUseCase = fetchApplicantListUseCase
+    }
+
+    @MainActor
+    func onAppear() {
+        Task {
+            do {
+                applicantList = try await fetchApplicantListUseCase(lectureID: lectureID)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/App/Sources/Feature/LectureListDetailFeature/LectureListDetailView.swift
+++ b/App/Sources/Feature/LectureListDetailFeature/LectureListDetailView.swift
@@ -117,14 +117,24 @@ struct LectureListDetailView: View {
                     }
                 }
                 .overlay(alignment: .bottom) {
-                    if viewModel.userAuthority == .student {
+                    switch viewModel.userAuthority {
+                    case .student:
                         if viewModel.lectureDetail?.isRegistered ?? true {
                             cancelPopupButton()
                         } else {
                             applyPopupButton()
                         }
-                    } else if viewModel.userAuthority == .teacher || viewModel.userAuthority == .admin {
+
+                    case .admin,
+                         .teacher,
+                         .professor,
+                         .companyInstructor,
+                         .government,
+                         .bbozzack:
                         checkApplicantListButton()
+
+                    default:
+                        EmptyView()
                     }
                 }
                 .bitgouelAlert(

--- a/Service/Sources/Data/DataSource/Lecture/RemoteLectureDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/Lecture/RemoteLectureDataSourceImpl.swift
@@ -42,4 +42,8 @@ public final class RemoteLectureDataSourceImpl: BaseRemoteDataSource<LectureAPI>
         try await request(.fetchAppliedLectureList(studentID: studentID), dto: FetchAppliedLectureListResponseDTO.self)
             .toDomain()
     }
+
+    public func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity] {
+        try await request(.fetchApplicantList(lectureID: lectureID), dto: FetchApplicantListResponseDTO.self).toDomain()
+    }
 }

--- a/Service/Sources/Data/DataSource/Lecture/RemoteLectureDataSourceImpl.swift
+++ b/Service/Sources/Data/DataSource/Lecture/RemoteLectureDataSourceImpl.swift
@@ -46,4 +46,8 @@ public final class RemoteLectureDataSourceImpl: BaseRemoteDataSource<LectureAPI>
     public func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity] {
         try await request(.fetchApplicantList(lectureID: lectureID), dto: FetchApplicantListResponseDTO.self).toDomain()
     }
+
+    public func modifyApplicantWhether(lectureID: String, studentID: String, isComplete: Bool) async throws {
+        try await request(.modifyApplicantWhether(lectureID: lectureID, studentID: studentID, isComplete: isComplete))
+    }
 }

--- a/Service/Sources/Data/Repository/Lecture/LectureRepositoryImpl.swift
+++ b/Service/Sources/Data/Repository/Lecture/LectureRepositoryImpl.swift
@@ -50,4 +50,8 @@ public struct LectureRepositoryImpl: LectureRepository {
     public func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity] {
         try await remoteLectureDataSource.fetchApplicantList(lectureID: lectureID)
     }
+
+    public func modifyApplicantWhether(lectureID: String, studentID: String, isComplete: Bool) async throws {
+        try await remoteLectureDataSource.modifyApplicantWhether(lectureID: lectureID, studentID: studentID, isComplete: isComplete)
+    }
 }

--- a/Service/Sources/Data/Repository/Lecture/LectureRepositoryImpl.swift
+++ b/Service/Sources/Data/Repository/Lecture/LectureRepositoryImpl.swift
@@ -46,4 +46,8 @@ public struct LectureRepositoryImpl: LectureRepository {
     public func fetchAppliedLectureList(studentID: String) async throws -> [AppliedLectureEntity] {
         try await remoteLectureDataSource.fetchAppliedLectureList(studentID: studentID)
     }
+
+    public func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity] {
+        try await remoteLectureDataSource.fetchApplicantList(lectureID: lectureID)
+    }
 }

--- a/Service/Sources/Data/UseCase/Lecture/FetchApplicantListUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/Lecture/FetchApplicantListUseCaseImpl.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct FetchApplicantListUseCaseImpl: FetchApplicantListUseCase {
+    private let lectureRepository: any LectureRepository
+
+    public init(lectureRepository: any LectureRepository) {
+        self.lectureRepository = lectureRepository
+    }
+
+    public func callAsFunction(lectureID: String) async throws -> [ApplicantInfoEntity] {
+        try await lectureRepository.fetchApplicantList(lectureID: lectureID)
+    }
+}

--- a/Service/Sources/Data/UseCase/Lecture/ModifyApplicantWhetherUseCaseImpl.swift
+++ b/Service/Sources/Data/UseCase/Lecture/ModifyApplicantWhetherUseCaseImpl.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct ModifyApplicantWhetherUseCaseImpl: ModifyApplicantWhetherUseCase {
+    private let lectureRepository: any LectureRepository
+
+    public init(lectureRepository: any LectureRepository) {
+        self.lectureRepository = lectureRepository
+    }
+
+    public func callAsFunction(lectureID: String, studentID: String, isComplete: Bool) async throws {
+        try await lectureRepository.modifyApplicantWhether(lectureID: lectureID, studentID: studentID, isComplete: isComplete)
+    }
+}

--- a/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
+++ b/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
@@ -13,6 +13,7 @@ public enum LectureAPI {
     case fetchDivisionList(keyword: String)
     case fetchAppliedLectureList(studentID: String)
     case fetchApplicantList(lectureID: String)
+    case modifyApplicantWhether(lectureID: String, studentID: String, isComplete: Bool)
 }
 
 extension LectureAPI: BitgouelAPI {
@@ -50,6 +51,9 @@ extension LectureAPI: BitgouelAPI {
 
         case let .fetchApplicantList(lectureID):
             return "/student/\(lectureID)"
+        
+        case let .modifyApplicantWhether(lectureID, studentID, _):
+            return "/\(lectureID)/\(studentID)"
         }
     }
 
@@ -71,6 +75,9 @@ extension LectureAPI: BitgouelAPI {
 
         case .cancelLecture:
             return .delete
+
+        case .modifyApplicantWhether:
+            return .patch
         }
     }
 
@@ -95,6 +102,11 @@ extension LectureAPI: BitgouelAPI {
             return .requestParameters(parameters: [
                 "keyword": keyword,
                 "division": division
+            ], encoding: URLEncoding.queryString)
+
+        case let .modifyApplicantWhether(_, _, isComplete):
+            return .requestParameters(parameters: [
+                "isComplete": isComplete
             ], encoding: URLEncoding.queryString)
 
         default:
@@ -141,7 +153,8 @@ extension LectureAPI: BitgouelAPI {
             ]
 
         case .applyLecture,
-             .cancelLecture:
+             .cancelLecture,
+             .modifyApplicantWhether:
             return [
                 400: .badRequest,
                 401: .unauthorized,

--- a/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
+++ b/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
@@ -12,6 +12,7 @@ public enum LectureAPI {
     case fetchDepartmentList(keyword: String)
     case fetchDivisionList(keyword: String)
     case fetchAppliedLectureList(studentID: String)
+    case fetchApplicantList(lectureID: String)
 }
 
 extension LectureAPI: BitgouelAPI {
@@ -46,6 +47,9 @@ extension LectureAPI: BitgouelAPI {
 
         case let .fetchAppliedLectureList(studentID):
             return "/\(studentID)/signup"
+
+        case let .fetchApplicantList(lectureID):
+            return "/student/\(lectureID)"
         }
     }
 
@@ -61,7 +65,8 @@ extension LectureAPI: BitgouelAPI {
              .fetchLineList,
              .fetchDepartmentList,
              .fetchDivisionList,
-             .fetchAppliedLectureList:
+             .fetchAppliedLectureList,
+             .fetchApplicantList:
             return .get
 
         case .cancelLecture:
@@ -118,7 +123,8 @@ extension LectureAPI: BitgouelAPI {
              .fetchInstructorList,
              .fetchLineList,
              .fetchDepartmentList,
-             .fetchDivisionList:
+             .fetchDivisionList,
+             .fetchApplicantList:
             return [
                 400: .badRequest,
                 401: .unauthorized,

--- a/Service/Sources/Domain/LectureDomain/DTO/Response/FetchApplicantListResponseDTO.swift
+++ b/Service/Sources/Domain/LectureDomain/DTO/Response/FetchApplicantListResponseDTO.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+public struct FetchApplicantListResponseDTO: Decodable {
+    public let students: [ApplicantInfoResponseDTO]
+
+    public init(students: [ApplicantInfoResponseDTO]) {
+        self.students = students
+    }
+}
+
+public struct ApplicantInfoResponseDTO: Decodable {
+    public let studentID: String
+    public let email: String
+    public let name: String
+    public let grade: Int
+    public let classNumber: Int
+    public let number: Int
+    public let phoneNumber: String
+    public let school: HighSchoolType
+    public let clubName: String
+    public let cohort: Int
+
+    public init(
+        studentID: String,
+        email: String,
+        name: String,
+        grade: Int,
+        classNumber: Int,
+        number: Int,
+        phoneNumber: String,
+        school: HighSchoolType,
+        clubName: String,
+        cohort: Int
+    ) {
+        self.studentID = studentID
+        self.email = email
+        self.name = name
+        self.grade = grade
+        self.classNumber = classNumber
+        self.number = number
+        self.phoneNumber = phoneNumber
+        self.school = school
+        self.clubName = clubName
+        self.cohort = cohort
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case studentID = "id"
+        case email
+        case name
+        case grade
+        case classNumber
+        case number
+        case phoneNumber
+        case school
+        case clubName
+        case cohort
+    }
+}
+
+extension FetchApplicantListResponseDTO {
+    func toDomain() -> [ApplicantInfoEntity] {
+        students.map { $0.toDomain() }
+    }
+}
+
+extension ApplicantInfoResponseDTO {
+    func toDomain() -> ApplicantInfoEntity {
+        ApplicantInfoEntity(
+            studentID: studentID,
+            email: email,
+            name: name,
+            grade: grade,
+            classNumber: classNumber,
+            number: number,
+            phoneNumber: phoneNumber,
+            school: school,
+            clubName: clubName,
+            cohort: cohort
+        )
+    }
+}

--- a/Service/Sources/Domain/LectureDomain/DTO/Response/FetchApplicantListResponseDTO.swift
+++ b/Service/Sources/Domain/LectureDomain/DTO/Response/FetchApplicantListResponseDTO.swift
@@ -19,6 +19,7 @@ public struct ApplicantInfoResponseDTO: Decodable {
     public let school: HighSchoolType
     public let clubName: String
     public let cohort: Int
+    public let isComplete: Bool
 
     public init(
         studentID: String,
@@ -30,7 +31,8 @@ public struct ApplicantInfoResponseDTO: Decodable {
         phoneNumber: String,
         school: HighSchoolType,
         clubName: String,
-        cohort: Int
+        cohort: Int,
+        isComplete: Bool
     ) {
         self.studentID = studentID
         self.email = email
@@ -42,6 +44,7 @@ public struct ApplicantInfoResponseDTO: Decodable {
         self.school = school
         self.clubName = clubName
         self.cohort = cohort
+        self.isComplete = isComplete
     }
 
     enum CodingKeys: String, CodingKey {
@@ -55,6 +58,7 @@ public struct ApplicantInfoResponseDTO: Decodable {
         case school
         case clubName
         case cohort
+        case isComplete
     }
 }
 
@@ -76,7 +80,8 @@ extension ApplicantInfoResponseDTO {
             phoneNumber: phoneNumber,
             school: school,
             clubName: clubName,
-            cohort: cohort
+            cohort: cohort,
+            isComplete: isComplete
         )
     }
 }

--- a/Service/Sources/Domain/LectureDomain/DataSource/RemoteLectureDataSource.swift
+++ b/Service/Sources/Domain/LectureDomain/DataSource/RemoteLectureDataSource.swift
@@ -11,4 +11,5 @@ public protocol RemoteLectureDataSource: BaseRemoteDataSource<LectureAPI> {
     func fetchDepartmentList(keyword: String) async throws -> [String]
     func fetchDivisionList(keyword: String) async throws -> [String]
     func fetchAppliedLectureList(studentID: String) async throws -> [AppliedLectureEntity]
+    func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity]
 }

--- a/Service/Sources/Domain/LectureDomain/DataSource/RemoteLectureDataSource.swift
+++ b/Service/Sources/Domain/LectureDomain/DataSource/RemoteLectureDataSource.swift
@@ -12,4 +12,5 @@ public protocol RemoteLectureDataSource: BaseRemoteDataSource<LectureAPI> {
     func fetchDivisionList(keyword: String) async throws -> [String]
     func fetchAppliedLectureList(studentID: String) async throws -> [AppliedLectureEntity]
     func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity]
+    func modifyApplicantWhether(lectureID: String, studentID: String, isComplete: Bool) async throws
 }

--- a/Service/Sources/Domain/LectureDomain/Entity/ApplicantInfoEntity.swift
+++ b/Service/Sources/Domain/LectureDomain/Entity/ApplicantInfoEntity.swift
@@ -11,6 +11,7 @@ public struct ApplicantInfoEntity: Equatable {
     public let school: HighSchoolType
     public let clubName: String
     public let cohort: Int
+    public let isComplete: Bool
 
     public init(
         studentID: String,
@@ -22,7 +23,8 @@ public struct ApplicantInfoEntity: Equatable {
         phoneNumber: String,
         school: HighSchoolType,
         clubName: String,
-        cohort: Int
+        cohort: Int,
+        isComplete: Bool
     ) {
         self.studentID = studentID
         self.email = email
@@ -34,5 +36,6 @@ public struct ApplicantInfoEntity: Equatable {
         self.school = school
         self.clubName = clubName
         self.cohort = cohort
+        self.isComplete = isComplete
     }
 }

--- a/Service/Sources/Domain/LectureDomain/Entity/ApplicantInfoEntity.swift
+++ b/Service/Sources/Domain/LectureDomain/Entity/ApplicantInfoEntity.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public struct ApplicantInfoEntity: Equatable {
+    public let studentID: String
+    public let email: String
+    public let name: String
+    public let grade: Int
+    public let classNumber: Int
+    public let number: Int
+    public let phoneNumber: String
+    public let school: HighSchoolType
+    public let clubName: String
+    public let cohort: Int
+
+    public init(
+        studentID: String,
+        email: String,
+        name: String,
+        grade: Int,
+        classNumber: Int,
+        number: Int,
+        phoneNumber: String,
+        school: HighSchoolType,
+        clubName: String,
+        cohort: Int
+    ) {
+        self.studentID = studentID
+        self.email = email
+        self.name = name
+        self.grade = grade
+        self.classNumber = classNumber
+        self.number = number
+        self.phoneNumber = phoneNumber
+        self.school = school
+        self.clubName = clubName
+        self.cohort = cohort
+    }
+}

--- a/Service/Sources/Domain/LectureDomain/Repository/LectureRepository.swift
+++ b/Service/Sources/Domain/LectureDomain/Repository/LectureRepository.swift
@@ -11,4 +11,5 @@ public protocol LectureRepository {
     func fetchDepartmentList(keyword: String) async throws -> [String]
     func fetchDivisionList(keyword: String) async throws -> [String]
     func fetchAppliedLectureList(studentID: String) async throws -> [AppliedLectureEntity]
+    func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity]
 }

--- a/Service/Sources/Domain/LectureDomain/Repository/LectureRepository.swift
+++ b/Service/Sources/Domain/LectureDomain/Repository/LectureRepository.swift
@@ -12,4 +12,5 @@ public protocol LectureRepository {
     func fetchDivisionList(keyword: String) async throws -> [String]
     func fetchAppliedLectureList(studentID: String) async throws -> [AppliedLectureEntity]
     func fetchApplicantList(lectureID: String) async throws -> [ApplicantInfoEntity]
+    func modifyApplicantWhether(lectureID: String, studentID: String, isComplete: Bool) async throws
 }

--- a/Service/Sources/Domain/LectureDomain/UseCase/FetchApplicantListUseCase.swift
+++ b/Service/Sources/Domain/LectureDomain/UseCase/FetchApplicantListUseCase.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol FetchApplicantListUseCase {
+    func callAsFunction(lectureID: String) async throws -> [ApplicantInfoEntity]
+}

--- a/Service/Sources/Domain/LectureDomain/UseCase/ModifyApplicantWhetherUseCase.swift
+++ b/Service/Sources/Domain/LectureDomain/UseCase/ModifyApplicantWhetherUseCase.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol ModifyApplicantWhetherUseCase {
+    func callAsFunction(lectureID: String, studentID: String, isComplete: Bool) async throws
+}


### PR DESCRIPTION
## 💡 배경 및 개요
강의 이수 중인 학생 전체 조회, 강의 이수 여부 수정 기능 추가

Resolves: #291 

## 📃 작업내용
- 강의 이수 중인 학생 전체 조회, 강의 이수 여부 수정 기능을 추가 했어요.
- 강의 이수 중인 학생 조회 기능 권한을 admin, teacher에서 admin, teacher, professor, companyinstructor, government, bbozzack으로 확대했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
