### PR TITLE
🔀 :: [#305] 답변되지 않은 문의사항일 때 답변됨 표시 수정

### DIFF
--- a/App/Sources/Feature/InquiryDetailFeature/Source/InquiryDetailView.swift
+++ b/App/Sources/Feature/InquiryDetailFeature/Source/InquiryDetailView.swift
@@ -27,12 +27,14 @@ struct InquiryDetailView: View {
 
                         Spacer()
 
-                        HStack(spacing: 0) {
-                            Text(inquiryInfo.answeredDate?.toStringCustomFormat(format: "yyyy.M.dd") ?? "")
-
-                            Text("에 답변됨")
+                        if inquiryInfo.answerStatus == .answered {
+                            HStack(spacing: 0) {
+                                Text(inquiryInfo.answeredDate?.toStringCustomFormat(format: "yyyy.MM.dd") ?? "")
+                                
+                                Text("에 답변됨")
+                            }
+                            .foregroundColor(.bitgouel(.greyscale(.g7)))
                         }
-                        .foregroundColor(.bitgouel(.greyscale(.g7)))
                     }
                     .font(.bitgouel(.caption))
 
@@ -44,7 +46,7 @@ struct InquiryDetailView: View {
 
                     HStack {
                         BitgouelText(
-                            text: inquiryInfo.questionDate.toStringCustomFormat(format: "yyyy.M.dd"),
+                            text: inquiryInfo.questionDate.toStringCustomFormat(format: "yyyy.MM.dd"),
                             font: .text3
                         )
                         BitgouelText(


### PR DESCRIPTION
## 💡 배경 및 개요
테스트 중 문의사항 상세보기페이지에서 답변되지 않은 문의사항일 때 답변됨 표시가 뜨는 문제가 있었어요.

Resolves: #305 

## 📃 작업내용
- 답변되지 않은 문의사항일 때 답변됨 표시가 뜨지 않도록 수정했어요.
- 문의사항을 작성한 시간을 보여주는 Date가 포맷이 잘못되어있어서 수정했어요.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?