### PR TITLE
🔀 :: [#308] 어드민 - 가입 요청자, 탈퇴 예정자 페이지에 유저가 없을 때 NoInfoView 추가

### DIFF
--- a/App/Sources/DesignSystem/View/NoInfoView.swift
+++ b/App/Sources/DesignSystem/View/NoInfoView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 struct NoInfoView: View {
+    var text: String
+
     var body: some View {
         VStack {
             BitgouelAsset.Icons.emptyBox.swiftUIImage
 
-            Text("검색 결과가 없습니다")
+            Text(text)
                 .bitgouelFont(.text3, color: .greyscale(.g4))
         }
     }

--- a/App/Sources/Feature/ActivityListFeature/Source/ActivityListView.swift
+++ b/App/Sources/Feature/ActivityListFeature/Source/ActivityListView.swift
@@ -24,7 +24,7 @@ struct ActivityListView: View {
             if !viewModel.isLoading {
                 if let activityList = viewModel.activityList {
                     if activityList.content.isEmpty {
-                        NoInfoView()
+                        NoInfoView(text: "활동이 없어요")
                     } else {
                         ScrollView {
                             LazyVStack(spacing: 12) {

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
@@ -55,31 +55,12 @@ struct AdminRequestUserSignupView: View {
                     } else {
                         LazyVStack(alignment: .leading, spacing: 0) {
                             ForEach(viewModel.userList, id: \.userID) { userInfo in
-                                HStack(spacing: 8) {
-                                    CheckButton(
-                                        isSelected: Binding(
-                                            get: { viewModel.selectedUserList.contains(userInfo.userID) },
-                                            set: { isSelected in
-                                                viewModel.insertUserList(userID: userInfo.userID)
-                                                if !isSelected {
-                                                    viewModel.removeUserList(userID: userInfo.userID)
-                                                }
-                                            }
-                                        )
-                                    )
-                                    
-                                    BitgouelText(
-                                        text: userInfo.name,
-                                        font: .text1
-                                    )
-                                    
-                                    BitgouelText(
-                                        text: userInfo.authority.display(),
-                                        font: .text1
-                                    )
-                                    .foregroundColor(.bitgouel(.greyscale(.g6)))
-                                }
-                                
+                                requestUserListRow(
+                                    userID: userInfo.userID,
+                                    userName: userInfo.name,
+                                    userAuthority: userInfo.authority.display()
+                                )
+
                                 Divider()
                                     .frame(height: 1)
                                     .padding(.vertical, 14)
@@ -163,6 +144,38 @@ struct AdminRequestUserSignupView: View {
                 set: { _ in viewModel.withdrawListPageDismissed() }
             )
         )
+    }
+
+    @ViewBuilder
+    func requestUserListRow(
+        userID: String,
+        userName: String,
+        userAuthority: String
+    ) -> some View {
+        HStack(spacing: 8) {
+            CheckButton(
+                isSelected: Binding(
+                    get: { viewModel.selectedUserList.contains(userID) },
+                    set: { isSelected in
+                        viewModel.insertUserList(userID: userID)
+                        if !isSelected {
+                            viewModel.removeUserList(userID: userID)
+                        }
+                    }
+                )
+            )
+
+            BitgouelText(
+                text: userName,
+                font: .text1
+            )
+
+            BitgouelText(
+                text: userAuthority,
+                font: .text1
+            )
+            .foregroundColor(.bitgouel(.greyscale(.g6)))
+        }
     }
 
     @ViewBuilder

--- a/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
+++ b/App/Sources/Feature/AdminRequestUserSignupFeature/Source/AdminRequestUserSignupView.swift
@@ -50,36 +50,40 @@ struct AdminRequestUserSignupView: View {
                 .padding(.top, 24)
 
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(viewModel.userList, id: \.userID) { userInfo in
-                            HStack(spacing: 8) {
-                                CheckButton(
-                                    isSelected: Binding(
-                                        get: { viewModel.selectedUserList.contains(userInfo.userID) },
-                                        set: { isSelected in
-                                            viewModel.insertUserList(userID: userInfo.userID)
-                                            if !isSelected {
-                                                viewModel.removeUserList(userID: userInfo.userID)
+                    if viewModel.userList.isEmpty {
+                        NoInfoView(text: "가입 요청자가 없어요")
+                    } else {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(viewModel.userList, id: \.userID) { userInfo in
+                                HStack(spacing: 8) {
+                                    CheckButton(
+                                        isSelected: Binding(
+                                            get: { viewModel.selectedUserList.contains(userInfo.userID) },
+                                            set: { isSelected in
+                                                viewModel.insertUserList(userID: userInfo.userID)
+                                                if !isSelected {
+                                                    viewModel.removeUserList(userID: userInfo.userID)
+                                                }
                                             }
-                                        }
+                                        )
                                     )
-                                )
-
-                                BitgouelText(
-                                    text: userInfo.name,
-                                    font: .text1
-                                )
-
-                                BitgouelText(
-                                    text: userInfo.authority.display(),
-                                    font: .text1
-                                )
-                                .foregroundColor(.bitgouel(.greyscale(.g6)))
+                                    
+                                    BitgouelText(
+                                        text: userInfo.name,
+                                        font: .text1
+                                    )
+                                    
+                                    BitgouelText(
+                                        text: userInfo.authority.display(),
+                                        font: .text1
+                                    )
+                                    .foregroundColor(.bitgouel(.greyscale(.g6)))
+                                }
+                                
+                                Divider()
+                                    .frame(height: 1)
+                                    .padding(.vertical, 14)
                             }
-
-                            Divider()
-                                .frame(height: 1)
-                                .padding(.vertical, 14)
                         }
                     }
                 }

--- a/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
+++ b/App/Sources/Feature/AdminWithdrawUserListFeature/Source/AdminWithdrawUserListView.swift
@@ -65,30 +65,36 @@ struct AdminWithdrawUserListView: View {
                 }
                 .padding(.top, 24)
 
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(viewModel.userList, id: \.userID) { userInfo in
-                        HStack(spacing: 8) {
-                            CheckButton(
-                                isSelected: Binding(
-                                    get: { viewModel.selectedWithdrawUserList.contains(userInfo.userID) },
-                                    set: { isSelected in
-                                        viewModel.insertUserList(userID: userInfo.userID)
-                                        if !isSelected {
-                                            viewModel.removeUserList(userID: userInfo.userID)
-                                        }
-                                    }
-                                )
-                            )
-
-                            BitgouelText(
-                                text: userInfo.name,
-                                font: .text1
-                            )
+                ScrollView {
+                    if viewModel.userList.isEmpty {
+                        NoInfoView(text: "탈퇴 예정자가 없어요")
+                    } else {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(viewModel.userList, id: \.userID) { userInfo in
+                                HStack(spacing: 8) {
+                                    CheckButton(
+                                        isSelected: Binding(
+                                            get: { viewModel.selectedWithdrawUserList.contains(userInfo.userID) },
+                                            set: { isSelected in
+                                                viewModel.insertUserList(userID: userInfo.userID)
+                                                if !isSelected {
+                                                    viewModel.removeUserList(userID: userInfo.userID)
+                                                }
+                                            }
+                                        )
+                                    )
+                                    
+                                    BitgouelText(
+                                        text: userInfo.name,
+                                        font: .text1
+                                    )
+                                }
+                                
+                                Divider()
+                                    .frame(height: 1)
+                                    .padding(.vertical, 14)
+                            }
                         }
-
-                        Divider()
-                            .frame(height: 1)
-                            .padding(.vertical, 14)
                     }
                 }
                 .padding(.top, 24)

--- a/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
+++ b/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
@@ -36,7 +36,7 @@ struct InquiryListView: View {
                     }
 
                     if viewModel.inquiryList.isEmpty {
-                        NoInfoView()
+                        NoInfoView(text: "문의사항이 없어요")
                     } else {
                         ScrollView {
                             VStack(spacing: 12) {

--- a/App/Sources/Feature/LectureDetailSettingFeature/Sources/Component/BottomSheet/InstructorBottomSheet.swift
+++ b/App/Sources/Feature/LectureDetailSettingFeature/Sources/Component/BottomSheet/InstructorBottomSheet.swift
@@ -16,7 +16,7 @@ struct InstructorBottomSheet: View {
 
             ScrollView(showsIndicators: false) {
                 if instructorList.isEmpty {
-                    NoInfoView()
+                    NoInfoView(text: "담당 교수가 없어요")
                         .padding(.top, 24)
                 } else {
                     LazyVStack(alignment: .leading, spacing: 16) {

--- a/App/Sources/Feature/LectureListFeature/Source/LectureListView.swift
+++ b/App/Sources/Feature/LectureListFeature/Source/LectureListView.swift
@@ -28,7 +28,7 @@ struct LectureListView: View {
                 if !viewModel.isLoading {
                     if let lectureList = viewModel.lectureList {
                         if lectureList.content.isEmpty {
-                            NoInfoView()
+                            NoInfoView(text: "강의가 없어요")
                         } else {
                             ScrollView {
                                 LazyVStack(alignment: .leading) {

--- a/App/Sources/Feature/MainFeature/Source/MainView.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainView.swift
@@ -18,12 +18,13 @@ struct MainView: View {
             VStack(spacing: 64) {
                 VStack(spacing: 64) {
                     BitgouelPromotionView()
+                        .padding(.horizontal, 28)
 
                     HighSchoolPromotionView()
 
                     ClubPromotionView()
+                        .padding(.horizontal, 28)
                 }
-                .padding(.horizontal, 28)
 
                 TabView {
                     FutureTransportClubView()

--- a/App/Sources/Feature/MainFeature/Source/View/HighSchoolPromotionView.swift
+++ b/App/Sources/Feature/MainFeature/Source/View/HighSchoolPromotionView.swift
@@ -7,6 +7,7 @@ struct HighSchoolPromotionView: View {
                 introduceTitle: "직업계고 소개",
                 introduceText: "직업계고 계열별 학교현황 및 진로"
             )
+            .padding(.horizontal, 28)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 24) {

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
@@ -25,7 +25,7 @@ struct NoticeListView: View {
         VStack {
             if let noticeInfo = viewModel.noticeContent {
                 if noticeInfo.content.isEmpty {
-                    NoInfoView()
+                    NoInfoView(text: "공지사항이 없어요")
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 0) {

--- a/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
+++ b/App/Sources/Feature/PostListFeature/Sources/PostListView.swift
@@ -31,7 +31,7 @@ struct PostListView: View {
             VStack {
                 if let postInfo = viewModel.postContent {
                     if postInfo.content.isEmpty {
-                        NoInfoView()
+                        NoInfoView(text: "게시글이 없어요")
                     } else {
                         ScrollView {
                             LazyVStack(spacing: 0) {


### PR DESCRIPTION
## 💡 배경 및 개요
테스트 중 어드민 페이지에서 가입 요청자, 탈퇴 예정자 페이지에 유저가 없을 때 NoInfoView가 보이는 것이 좋을 것 같다고 판단했어요.

Resolves: #308 

## 📃 작업내용
- 어드민 - 가입 요청자, 탈퇴 예정자 페이지에 유저가 없을 때 NoInfoView가 띄워지도록 수정했어요.
- NoInfoView에 text를 직접입력하도록 수정해서 원하는 정보가 없다고 정확히 알려줄 수 있도록 변경했어요.

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?