### PR TITLE
🔀 :: [#307] 동아리 목록 페이지 접근 권한 수정

### DIFF
--- a/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailView.swift
+++ b/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailView.swift
@@ -56,7 +56,6 @@ struct ClubDetailView: View {
                     }
                     .foregroundColor(.bitgouel(.greyscale(.g4)))
                 }
-                .padding(.top, -40)
 
                 VStack(alignment: .leading, spacing: 0) {
                     BitgouelText(
@@ -93,18 +92,24 @@ struct ClubDetailView: View {
                 }
             }
         }
+        .if(viewModel.authority != .admin) {
+            $0.navigationBarBackButtonHidden()
+        }
         .navigate(
             to: studentInfoFactory.makeView(
                 clubID: viewModel.clubID,
                 studentID: viewModel.studentID
             ).eraseToAnyView(),
             when: Binding(
-                get: { viewModel.isPresentedCertificationView },
+                get: { viewModel.isPresentedStudentInfoView },
                 set: { isPresented in
-                    viewModel.updateIsPresentedCertificationView(isPresented: isPresented)
+                    viewModel.updateIsPresentedStudentInfoView(isPresented: isPresented)
                 }
             )
         )
+        .onChange(of: viewModel.isPresentedStudentInfoView) { newValue in
+            tabbarHidden.wrappedValue = newValue
+        }
         .padding(.horizontal, 28)
         .onAppear {
             viewModel.onAppear()

--- a/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailViewModel.swift
+++ b/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 final class ClubDetailViewModel: BaseViewModel {
     @Published var authority: UserAuthorityType = .user
     @Published var userID: String = ""
-    @Published var isPresentedCertificationView: Bool = false
+    @Published var isPresentedStudentInfoView: Bool = false
     @Published var studentID: String = ""
 
     // MARK: ClubInfo
@@ -72,12 +72,12 @@ final class ClubDetailViewModel: BaseViewModel {
         self.teacher = clubInfo.teacher
     }
 
-    func updateIsPresentedCertificationView(isPresented: Bool) {
-        isPresentedCertificationView = isPresented
+    func updateIsPresentedStudentInfoView(isPresented: Bool) {
+        isPresentedStudentInfoView = isPresented
     }
 
     func studentInfoRowDidTap(selectedStudentID: String) {
         studentID = selectedStudentID
-        updateIsPresentedCertificationView(isPresented: true)
+        updateIsPresentedStudentInfoView(isPresented: true)
     }
 }

--- a/App/Sources/Feature/ClubListFeature/Source/ClubListView.swift
+++ b/App/Sources/Feature/ClubListFeature/Source/ClubListView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct ClubListView: View {
-    @Environment(\.tabbarHidden) var tabbarHidden
     @StateObject var viewModel: ClubListViewModel
     @Binding var selection: TabFlow
 
@@ -102,9 +101,6 @@ struct ClubListView: View {
                     set: { state in viewModel.isPresentedClubDetailView = state }
                 )
             )
-            .onChange(of: viewModel.isPresentedClubDetailView) { newValue in
-                tabbarHidden.wrappedValue = newValue
-            }
             .loginAlert(
                 isShowing: Binding(
                     get: { viewModel.isShowingLoginAlert },

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/Component/LectureApplicantListRow.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/Component/LectureApplicantListRow.swift
@@ -38,7 +38,7 @@ struct LectureApplicantListRow: View {
                 )
 
                 Group {
-                    Text("\(phoneNumber) | \(email)")
+                    Text("\(phoneNumber.withHypen) | \(email)")
 
                     Text(schoolName)
 

--- a/App/Sources/Feature/StudentInfoFeature/Source/StudentInfoView.swift
+++ b/App/Sources/Feature/StudentInfoFeature/Source/StudentInfoView.swift
@@ -64,7 +64,7 @@ struct StudentInfoView: View {
                         Spacer()
 
                         BitgouelText(
-                            text: studentInfo.phoneNumber,
+                            text: studentInfo.phoneNumber.withHypen,
                             font: .caption
                         )
                     }

--- a/App/Sources/Utils/Extensions/String+withHypen.swift
+++ b/App/Sources/Utils/Extensions/String+withHypen.swift
@@ -1,0 +1,9 @@
+//
+//  String.swift
+//  Bitgouel
+//
+//  Created by 정윤서 on 5/9/24.
+//  Copyright © 2024 team.msg. All rights reserved.
+//
+
+import Foundation

--- a/App/Sources/Utils/Extensions/String+withHypen.swift
+++ b/App/Sources/Utils/Extensions/String+withHypen.swift
@@ -1,9 +1,12 @@
-//
-//  String.swift
-//  Bitgouel
-//
-//  Created by 정윤서 on 5/9/24.
-//  Copyright © 2024 team.msg. All rights reserved.
-//
-
 import Foundation
+
+extension String {
+  public var withHypen: String {
+    var stringWithHypen: String = self
+    
+    stringWithHypen.insert("-", at: stringWithHypen.index(stringWithHypen.startIndex, offsetBy: 3))
+    stringWithHypen.insert("-", at: stringWithHypen.index(stringWithHypen.endIndex, offsetBy: -4))
+    
+    return stringWithHypen
+  }
+}


### PR DESCRIPTION
## 💡 배경 및 개요
어드민 제외 유저 역할들은 동아리 탭을 선택했을 때 바로 유저가 소속되어있는 동아리의 상세페이지로 이동하게 되어있어요.
그러나, 동아리 상세페이지의 탭바가 Hidden되어있어서 어드민이 아닌 유저의 페이지 이동이
동아리 상세 -> 백버튼 -> 동아리 목록 -> 탭바 이동으로 되어있어서 이동이 불편했어요.

Resolves: #307 

## 📃 작업내용
- 어드민이 아닌 유저들의 동아리 목록 BackButton을 Hidden해서 동아리 목록페이지로 이동할 수 없게 변경했어요.
- 추가로 동아리 상세 페이지에 Tabbar Hidden을 삭제해 탭바 이동을 편하게 할 수 있도록 변경했어요.
- 전화번호 text가 010-0000-0000으로 표현되는 게 아니라 01000000000로 표현되어있어서 하이픈을 추가해주는 String Extensions을 추가했어요.

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
