### PR TITLE
🔀 :: [#313] FAQ추가 성공시 FAQ리스트 재요청

### DIFF
--- a/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
+++ b/App/Sources/Feature/MainFeature/Source/MainViewModel.swift
@@ -51,6 +51,7 @@ final class MainViewModel: BaseViewModel {
                 try await inputFAQUseCase(req: InputFAQRequestDTO(question: question, answer: answer))
 
                 updateInputFAQButtonDidTap(state: false)
+                onAppear()
             } catch {
                 print(error.localizedDescription)
             }


### PR DESCRIPTION
## 💡 배경 및 개요
어드민일 때 메인페이지에 FAQ 추가를 성공해도 FAQ가 추가되지 않는 오류가 있었어요.

Resolves: #313 

## 📃 작업내용
- FAQ 추가가 성공했을 때 onAppear함수를 한 번 더 호출하도록 변경했어요.

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?