### PR TITLE
🔀 :: [#319] 강의 유형 LectureType -> String으로 수정 

### DIFF
--- a/App/Sources/Feature/LectureListDetailFeature/LectureListDetailView.swift
+++ b/App/Sources/Feature/LectureListDetailFeature/LectureListDetailView.swift
@@ -23,7 +23,7 @@ struct LectureListDetailView: View {
                     if let lectureDetail = viewModel.lectureDetail {
                         VStack(alignment: .leading, spacing: 24) {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text("# \(lectureDetail.lectureType.rawValue)")
+                                Text("# \(lectureDetail.lectureType)")
                                     .bitgouelFont(.caption, color: .primary(.p3))
 
                                 HStack(spacing: 8) {

--- a/App/Sources/Feature/LectureListFeature/Source/Component/LectureListRow.swift
+++ b/App/Sources/Feature/LectureListFeature/Source/Component/LectureListRow.swift
@@ -10,7 +10,7 @@ struct LectureListRow: View {
     let line: String
     let startDate: String
     let endDate: String
-    let lectureType: LectureType
+    let lectureType: String
     let lectureStatus: LectureStatusType
     let headCount: Int
     let maxRegisteredUser: Int
@@ -24,7 +24,7 @@ struct LectureListRow: View {
 
                 Spacer()
 
-                Text(lectureType.rawValue)
+                Text(lectureType)
                     .bitgouelFont(.caption, color: .greyscale(.g4))
             }
 
@@ -34,6 +34,7 @@ struct LectureListRow: View {
             Text(content)
                 .bitgouelFont(.text3, color: .greyscale(.g4))
                 .lineLimit(2)
+                .multilineTextAlignment(.leading)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {

--- a/App/Sources/Feature/LectureListFeature/Source/LectureListView.swift
+++ b/App/Sources/Feature/LectureListFeature/Source/LectureListView.swift
@@ -192,6 +192,8 @@ struct LectureListView: View {
                         set: { lecture in
                             if lecture {
                                 viewModel.selectedLectureType = lectureType.rawValue
+                            } else {
+                                viewModel.selectedLectureType = ""
                             }
                         }
                     )

--- a/App/Sources/Feature/LectureListFeature/Source/LectureListViewModel.swift
+++ b/App/Sources/Feature/LectureListFeature/Source/LectureListViewModel.swift
@@ -33,14 +33,19 @@ final class LectureListViewModel: BaseViewModel {
         switch lectureType {
         case "상호학점인정교육과정":
             return type = .mutualCreditRecognitionProgram
+
         case "대학탐방프로그램":
             return type = .universityExplorationProgram
+
         case "유관기관프로그램":
             return type = .governmentProgram
+
         case "기업산학연계직업체험프로그램":
             return type = .companyIndustryLinkingJobExperienceProgram
+
         case "기타":
             return type = .etc
+
         default:
             return type = nil
         }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Club/AiFusionAndCompositeClubView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Club/AiFusionAndCompositeClubView.swift
@@ -63,6 +63,8 @@ struct AiFusionAndCompositeClubView: View {
         }
         .background(
             Image("mainpage_image_3")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Club/CultureIndustryClubView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Club/CultureIndustryClubView.swift
@@ -117,6 +117,8 @@ struct CultureIndustryClubView: View {
         }
         .background(
             Image("mainpage_image_6")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Club/EnergyIndustryClubView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Club/EnergyIndustryClubView.swift
@@ -123,6 +123,8 @@ struct EnergyIndustryClubView: View {
         }
         .background(
             Image("mainpage_image_4")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Club/FutureTransportClubView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Club/FutureTransportClubView.swift
@@ -99,6 +99,8 @@ struct FutureTransportClubView: View {
         }
         .background(
             Image("mainpage_image_2")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Club/MedicalHealthClubView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Club/MedicalHealthClubView.swift
@@ -87,6 +87,8 @@ struct MedicalHealthClubView: View {
         }
         .background(
             Image("mainpage_image_5")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Company/AiFusionAndCompositeCompanyView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Company/AiFusionAndCompositeCompanyView.swift
@@ -51,6 +51,8 @@ struct AiFusionAndCompositeCompanyView: View {
         }
         .background(
             Image("mainpage_image_10")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Company/CultureIndustryCompanyView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Company/CultureIndustryCompanyView.swift
@@ -85,6 +85,8 @@ struct CultureIndustryCompanyView: View {
         }
         .background(
             Image("mainpage_image_11")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Company/EnergyIndustryCompanyView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Company/EnergyIndustryCompanyView.swift
@@ -72,6 +72,8 @@ struct EnergyIndustryCompanyView: View {
         }
         .background(
             Image("mainpage_image_8")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Company/FutureTransportCompanyView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Company/FutureTransportCompanyView.swift
@@ -57,6 +57,8 @@ struct FutureTransportCompanyView: View {
         }
         .background(
             Image("mainpage_image_7")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/App/Sources/Feature/MainFeature/Source/TabView/Company/MedicalHealthCompanyView.swift
+++ b/App/Sources/Feature/MainFeature/Source/TabView/Company/MedicalHealthCompanyView.swift
@@ -51,6 +51,8 @@ struct MedicalHealthCompanyView: View {
         }
         .background(
             Image("mainpage_image_9")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .blur(radius: 6, opaque: true)
         )
     }

--- a/Service/Sources/Domain/LectureDomain/DTO/Response/FetchLectureDetailResponseDTO.swift
+++ b/Service/Sources/Domain/LectureDomain/DTO/Response/FetchLectureDetailResponseDTO.swift
@@ -11,7 +11,7 @@ public struct FetchLectureDetailResponseDTO: Decodable {
     public let startDate: String
     public let endDate: String
     public let lectureDates: [LectureDate]
-    public let lectureType: LectureType
+    public let lectureType: String
     public let lectureStatus: LectureStatusType
     public let headCount: Int
     public let maxRegisteredUser: Int
@@ -30,7 +30,7 @@ public struct FetchLectureDetailResponseDTO: Decodable {
         startDate: String,
         endDate: String,
         lectureDates: [LectureDate],
-        lectureType: LectureType,
+        lectureType: String,
         lectureStatus: LectureStatusType,
         headCount: Int,
         maxRegisteredUser: Int,

--- a/Service/Sources/Domain/LectureDomain/DTO/Response/FetchLectureListResponseDTO.swift
+++ b/Service/Sources/Domain/LectureDomain/DTO/Response/FetchLectureListResponseDTO.swift
@@ -28,7 +28,7 @@ public struct LectureInfoResponseDTO: Decodable {
     public let line: String
     public let startDate: String
     public let endDate: String
-    public let lectureType: LectureType
+    public let lectureType: String
     public let lectureStatus: LectureStatusType
     public let headCount: Int
     public let maxRegisteredUser: Int
@@ -44,7 +44,7 @@ public struct LectureInfoResponseDTO: Decodable {
         line: String,
         startDate: String,
         endDate: String,
-        lectureType: LectureType,
+        lectureType: String,
         lectureStatus: LectureStatusType,
         headCount: Int,
         maxRegisteredUser: Int,

--- a/Service/Sources/Domain/LectureDomain/Entity/LectureDetailEntity.swift
+++ b/Service/Sources/Domain/LectureDomain/Entity/LectureDetailEntity.swift
@@ -11,7 +11,7 @@ public struct LectureDetailEntity: Equatable {
     public let startDate: Date
     public let endDate: Date
     public let lectureDates: [LectureDateEntity]
-    public let lectureType: LectureType
+    public let lectureType: String
     public let lectureStatus: LectureStatusType
     public let headCount: Int
     public let maxRegisteredUser: Int
@@ -30,7 +30,7 @@ public struct LectureDetailEntity: Equatable {
         startDate: Date,
         endDate: Date,
         lectureDates: [LectureDateEntity],
-        lectureType: LectureType,
+        lectureType: String,
         lectureStatus: LectureStatusType,
         headCount: Int,
         maxRegisteredUser: Int,

--- a/Service/Sources/Domain/LectureDomain/Entity/LectureListEntity.swift
+++ b/Service/Sources/Domain/LectureDomain/Entity/LectureListEntity.swift
@@ -10,7 +10,7 @@ public struct LectureListEntity: Equatable {
     public let line: String
     public let startDate: Date
     public let endDate: Date
-    public let lectureType: LectureType
+    public let lectureType: String
     public let lectureStatus: LectureStatusType
     public let headCount: Int
     public let maxRegisteredUser: Int
@@ -26,7 +26,7 @@ public struct LectureListEntity: Equatable {
         line: String,
         startDate: Date,
         endDate: Date,
-        lectureType: LectureType,
+        lectureType: String,
         lectureStatus: LectureStatusType,
         headCount: Int,
         maxRegisteredUser: Int,


### PR DESCRIPTION
## 💡 배경 및 개요
강의 리스트, 상세를 Response하는 과정에서 LectureType이 String으로 오는데 저희가 정해놓은 enum인 LectureType으로 Type을 지정해 두어서 리스트, 상세를 Response 하지 못하는 문제가 있었어요.

Resolves: #319 

## 📃 작업내용
- LectureDomain - 강의 리스트, 상세 ResponseDTO, Entity의 LectureType을 String으로 수정했어요.
- 강의 리스트, 상세 보기 페이지에 LectureType을 String으로 변경했어요.

- 메인 페이지에 동아리, 참여기업을 소개하는 부분의 배경 Image가 크기가 큰 시뮬레이터로 빌드 했을 때 잘리는 문제가있어서 해결했어요.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?