### PR TITLE
🔀 :: [#325] 다크모드 제한 설정 추가

### DIFF
--- a/App/Support/Info.plist
+++ b/App/Support/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
## 💡 배경 및 개요
다크모드 디자인이 따로 없고 대응할 방안이 없는 상황에서 QA중 다크모드로 테스트하면서 제대로 UI가 그려지지 않는 문제가 있었어요.

Resolves: #325 

## 📃 작업내용
- 다크모드로 접근할 수 없도록 라이트 모드 제한을 추가했습니다.
- 
## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?