### PR TITLE
🔀 [#329] Domain별 Description 추가

### DIFF
--- a/Service/Sources/Domain/ActivityDomain/API/ActivityAPI.swift
+++ b/Service/Sources/Domain/ActivityDomain/API/ActivityAPI.swift
@@ -69,29 +69,10 @@ extension ActivityAPI: BitgouelAPI {
 
     public var errorMap: [Int: ErrorType] {
         switch self {
-        case .inputActivity,
-             .modifyActivity,
-             .deleteActivity,
-             .fetchActivityDetail:
+        default:
             return [
-                400: .badRequest,
-                401: .unauthorized,
                 403: .forbidden,
-                404: .notFound,
-                409: .conflict,
-                429: .tooManyRequest
-            ]
-        case .fetchMyActivity,
-             .fetchActivityByID,
-             .fetchActivityList:
-            return [
-                400: .badRequest,
-                401: .unauthorized,
-                403: .forbidden,
-                404: .notFound,
-                409: .conflict,
-                429: .tooManyRequest,
-                500: .internalServerError
+                404: .notFound
             ]
         }
     }

--- a/Service/Sources/Domain/ActivityDomain/Error/ActivityDomainError.swift
+++ b/Service/Sources/Domain/ActivityDomain/Error/ActivityDomainError.swift
@@ -1,32 +1,18 @@
 import Foundation
 
 public enum ActivityDomainError: Error {
-    case badRequest
-    case unauthorized
     case forbidden
     case notFound
-    case conflict
-    case tooManyRequest
-    case internalServerError
 }
 
 extension ActivityDomainError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .badRequest:
-            return "잘못된 요청입니다. 작성하지 않은 부분이 있는 지 확인해주세요."
-        case .unauthorized:
-            return "만료되었거나 식별할 수 없는 토큰입니다."
         case .forbidden:
             return "권한이 없습니다."
+
         case .notFound:
             return "대상을 찾을 수 없습니다."
-        case .conflict:
-            return "중복된 id입니다."
-        case .tooManyRequest:
-            return "요청이 너무 많습니다."
-        case .internalServerError:
-            return "서버에서 문제가 발생하였습니다. 지속될 시 문의해주세요."
         }
     }
 }

--- a/Service/Sources/Domain/AdminDomain/API/AdminAPI.swift
+++ b/Service/Sources/Domain/AdminDomain/API/AdminAPI.swift
@@ -78,33 +78,11 @@ extension AdminAPI: BitgouelAPI {
 
     public var errorMap: [Int: AdminDomainError] {
         switch self {
-        case .fetchUserList:
+        default:
             return [
-                400: .internalServerError,
-                401: .internalServerError,
-                403: .forbidden,
-                429: .internalServerError
-            ]
-
-        case .fetchUserDetail:
-            return [
-                400: .internalServerError,
-                401: .internalServerError,
-                403: .forbidden,
-                404: .internalServerError,
-                429: .internalServerError
-            ]
-
-        case .approveUserSignup,
-             .rejectUserSignup,
-             .withdrawUserSignup:
-            return [
-                400: .internalServerError,
-                401: .internalServerError,
-                403: .forbidden,
-                404: .internalServerError,
+                400: .badRequest,
                 409: .conflict,
-                429: .internalServerError
+                500: .internalServerError
             ]
         }
     }

--- a/Service/Sources/Domain/AdminDomain/Error/AdminDomainError.swift
+++ b/Service/Sources/Domain/AdminDomain/Error/AdminDomainError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum AdminDomainError: Error {
-    case forbidden
+    case badRequest
     case conflict
     case internalServerError
 }
@@ -9,12 +9,14 @@ public enum AdminDomainError: Error {
 extension AdminDomainError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .forbidden:
-            return "권한이 없습니다."
+        case .badRequest:
+            return "대상을 찾을 수 없습니다."
+
         case .conflict:
-            return "이미 완료된 유저입니다."
+            return "이미 승인된 유저입니다."
+
         case .internalServerError:
-            return "알 수 없는 에러가 발생했습니다. 지속될 시 문의 주세요."
+            return "서버 에러가 발생했습니다. 지속될 시 문의 주세요."
         }
     }
 }

--- a/Service/Sources/Domain/AuthDomain/API/AuthAPI.swift
+++ b/Service/Sources/Domain/AuthDomain/API/AuthAPI.swift
@@ -134,29 +134,14 @@ extension AuthAPI: BitgouelAPI {
         }
     }
 
-    public var errorMap: [Int: ErrorType] {
+    public var errorMap: [Int: AuthDomainError] {
         switch self {
-        case .studentSignup:
-            return [
-                400: .badRequest,
-                401: .unauthorized,
-                403: .forbidden,
-                404: .notFound,
-                409: .conflict,
-                429: .tooManyRequest
-            ]
-
         default:
             return [
-                400: .badRequest,
                 401: .unauthorized,
                 403: .forbidden,
                 404: .notFound,
-                407: .proxyAuthenticationRequired,
-                408: .requestTimeout,
-                409: .conflict,
-                429: .tooManyRequest,
-                500: .internalServerError
+                409: .conflict
             ]
         }
     }

--- a/Service/Sources/Domain/AuthDomain/Error/AuthDomainError.swift
+++ b/Service/Sources/Domain/AuthDomain/Error/AuthDomainError.swift
@@ -1,13 +1,26 @@
 import Foundation
 
 public enum AuthDomainError: Error {
-    case badRequest
     case unauthorized
     case forbidden
     case notFound
-    case proxyAuthenticationRequired
-    case requestTimeout
     case conflict
-    case tooManyRequest
-    case internalServerError
+}
+
+extension AuthDomainError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "유효하지 않은 리프레시 토큰입니다."
+
+        case .forbidden:
+            return "아직 회원가입 대기 중인 유저입니다."
+
+        case .notFound:
+            return "존재하지 않는 리프레시 토큰입니다."
+
+        case .conflict:
+            return "이미 가입된 유저의 정보를 기입하였습니다."
+        }
+    }
 }

--- a/Service/Sources/Domain/CertificationDomain/API/CertificationAPI.swift
+++ b/Service/Sources/Domain/CertificationDomain/API/CertificationAPI.swift
@@ -59,18 +59,10 @@ extension CertificationAPI: BitgouelAPI {
 
     public var errorMap: [Int: CertificationDomainError] {
         switch self {
-        case .queryCertificationListByTeacher,
-             .queryCertificationListByStudent:
+        default:
             return [
                 403: .forbidden,
-                404: .invalidRequest
-            ]
-
-        case .inputCertification,
-             .updateCertification:
-            return [
-                403: .forbidden,
-                404: .invalidRequest,
+                404: .notFound,
                 409: .conflict
             ]
         }

--- a/Service/Sources/Domain/CertificationDomain/Error/CertificationDomainError.swift
+++ b/Service/Sources/Domain/CertificationDomain/Error/CertificationDomainError.swift
@@ -2,8 +2,8 @@ import Foundation
 
 public enum CertificationDomainError: Error {
     case forbidden
+    case notFound
     case conflict
-    case invalidRequest
 }
 
 extension CertificationDomainError: LocalizedError {
@@ -11,10 +11,12 @@ extension CertificationDomainError: LocalizedError {
         switch self {
         case .forbidden:
             return "권한이 없습니다."
+
+        case .notFound:
+            return "대상을 찾을 수 없습니다."
+
         case .conflict:
-            return "이미 등록된 자격증입니다."
-        case .invalidRequest:
-            return "알 수 없는 에러가 발생하였습니다."
+            return "이미 취득한 자격증입니다."
         }
     }
 }

--- a/Service/Sources/Domain/ClubDomain/API/ClubAPI.swift
+++ b/Service/Sources/Domain/ClubDomain/API/ClubAPI.swift
@@ -63,16 +63,10 @@ extension ClubAPI: BitgouelAPI {
 
     public var errorMap: [Int: ClubDomainError] {
         switch self {
-        case .queryClubList,
-             .queryClubDetail,
-             .queryStudentListByClub,
-             .queryStudentDetailByClub:
+        default:
             return [
-                400: .badRequest,
                 401: .unauthorized,
-                403: .forbidden,
-                404: .notFound,
-                429: .tooManyRequest
+                404: .notFound
             ]
         }
     }

--- a/Service/Sources/Domain/ClubDomain/Error/ClubDomainError.swift
+++ b/Service/Sources/Domain/ClubDomain/Error/ClubDomainError.swift
@@ -1,9 +1,18 @@
 import Foundation
 
 public enum ClubDomainError: Error {
-    case badRequest
     case unauthorized
-    case forbidden
     case notFound
-    case tooManyRequest
+}
+
+extension ClubDomainError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "유효하지 않은 권한입니다."
+
+        case .notFound:
+            return "대상을 찾을 수 없습니다."
+        }
+    }
 }

--- a/Service/Sources/Domain/EmailDomain/API/EmailAPI.swift
+++ b/Service/Sources/Domain/EmailDomain/API/EmailAPI.swift
@@ -7,7 +7,7 @@ public enum EmailAPI {
 }
 
 extension EmailAPI: BitgouelAPI {
-    public typealias ErrorType = ActivityDomainError
+    public typealias ErrorType = AdminDomainError
 
     public var domain: BitgouelDomain {
         .email
@@ -49,18 +49,11 @@ extension EmailAPI: BitgouelAPI {
         }
     }
 
-    public var errorMap: [Int: ActivityDomainError] {
+    public var errorMap: [Int: AdminDomainError] {
         switch self {
-        case .sendEmailCertificationLink:
+        default:
             return [
-                400: .badRequest,
-                429: .tooManyRequest,
                 500: .internalServerError
-            ]
-        case .fetchEmailVerificationStatus:
-            return [
-                400: .badRequest,
-                401: .unauthorized
             ]
         }
     }

--- a/Service/Sources/Domain/FAQDomain/API/FAQAPI.swift
+++ b/Service/Sources/Domain/FAQDomain/API/FAQAPI.swift
@@ -53,20 +53,9 @@ extension FAQAPI: BitgouelAPI {
 
     public var errorMap: [Int: FAQDomainError] {
         switch self {
-        case .inputFAQ:
+        default:
             return [
-                400: .internalServerError,
-                401: .internalServerError,
-                403: .forbidden,
-                409: .conflict,
-                429: .internalServerError
-            ]
-
-        case .fetchFAQList:
-            return [
-                400: .internalServerError,
-                401: .internalServerError,
-                429: .internalServerError
+                404: .notFound
             ]
         }
     }

--- a/Service/Sources/Domain/FAQDomain/Error/FAQDomainError.swift
+++ b/Service/Sources/Domain/FAQDomain/Error/FAQDomainError.swift
@@ -1,20 +1,14 @@
 import Foundation
 
 public enum FAQDomainError: Error {
-    case forbidden
-    case conflict
-    case internalServerError
+    case notFound
 }
 
 extension FAQDomainError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .forbidden:
-            return "권한이 없습니다."
-        case .conflict:
-            return "이미 작성되어있는 질문입니다."
-        case .internalServerError:
-            return "알 수 없는 에러가 발생했습니다. 지속될 시 문의 주세요."
+        case .notFound:
+            return "존재하지 않는 어드민입니다."
         }
     }
 }

--- a/Service/Sources/Domain/InquiryDomain/API/InquiryAPI.swift
+++ b/Service/Sources/Domain/InquiryDomain/API/InquiryAPI.swift
@@ -90,41 +90,11 @@ extension InquiryAPI: BitgouelAPI {
 
     public var errorMap: [Int: InquiryDomainError] {
         switch self {
-        case .inputInquiry,
-             .modifyMyInquiry:
+        default:
             return [
-                400: .invalidRequest,
-                401: .invalidRequest,
-                404: .invalidRequest,
-                409: .conflict,
-                429: .invalidRequest
-            ]
-
-        case .fetchMyInquiryList,
-             .deleteMyInquiry:
-            return [
-                400: .invalidRequest,
-                401: .invalidRequest,
-                429: .invalidRequest
-            ]
-
-        case .fetchInquiryDetail:
-            return [
-                400: .invalidRequest,
-                401: .invalidRequest,
-                404: .invalidRequest,
-                429: .invalidRequest
-            ]
-
-        case .replyInquiry,
-             .fetchInquiryListByAdmin,
-             .deleteInquiryByAdmin:
-            return [
-                400: .invalidRequest,
-                401: .invalidRequest,
                 403: .forbidden,
-                404: .invalidRequest,
-                429: .invalidRequest
+                404: .notFound,
+                409: .conflict
             ]
         }
     }

--- a/Service/Sources/Domain/InquiryDomain/Error/InquiryDomainError.swift
+++ b/Service/Sources/Domain/InquiryDomain/Error/InquiryDomainError.swift
@@ -2,8 +2,8 @@ import Foundation
 
 public enum InquiryDomainError: Error {
     case forbidden
+    case notFound
     case conflict
-    case invalidRequest
 }
 
 extension InquiryDomainError: LocalizedError {
@@ -11,10 +11,12 @@ extension InquiryDomainError: LocalizedError {
         switch self {
         case .forbidden:
             return "권한이 없습니다."
+
+        case .notFound:
+            return "존재하지 않는 문의사항입니다."
+
         case .conflict:
-            return "같은 문의사항이 존재합니다."
-        case .invalidRequest:
-            return "알 수 없는 에러가 발생하였습니다."
+            return "이미 답변이 등록된 문의사항입니다."
         }
     }
 }

--- a/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
+++ b/Service/Sources/Domain/LectureDomain/API/LectureAPI.swift
@@ -123,45 +123,11 @@ extension LectureAPI: BitgouelAPI {
 
     public var errorMap: [Int: LectureDomainError] {
         switch self {
-        case .openLecture:
+        default:
             return [
-                400: .badRequest,
-                401: .unauthorized,
-                403: .forbidden,
-                409: .conflict
-            ]
-
-        case .fetchLectureList,
-             .fetchInstructorList,
-             .fetchLineList,
-             .fetchDepartmentList,
-             .fetchDivisionList,
-             .fetchApplicantList:
-            return [
-                400: .badRequest,
-                401: .unauthorized,
-                403: .forbidden
-            ]
-
-        case .fetchLectureDetail,
-             .fetchAppliedLectureList:
-            return [
-                400: .badRequest,
-                401: .unauthorized,
-                403: .forbidden,
-                404: .notFound
-            ]
-
-        case .applyLecture,
-             .cancelLecture,
-             .modifyApplicantWhether:
-            return [
-                400: .badRequest,
-                401: .unauthorized,
                 403: .forbidden,
                 404: .notFound,
-                409: .conflict,
-                429: .tooManyRequest
+                409: .conflict
             ]
         }
     }

--- a/Service/Sources/Domain/LectureDomain/Error/LectureDomainError.swift
+++ b/Service/Sources/Domain/LectureDomain/Error/LectureDomainError.swift
@@ -1,23 +1,14 @@
 import Foundation
 
 public enum LectureDomainError: Error {
-    case badRequest
-    case unauthorized
     case forbidden
     case notFound
     case conflict
-    case tooManyRequest
 }
 
 extension LectureDomainError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .badRequest:
-            return "잘못된 요청입니다."
-
-        case .unauthorized:
-            return "인증을 실패했습니다."
-
         case .forbidden:
             return "권한이 없습니다."
 
@@ -25,10 +16,7 @@ extension LectureDomainError: LocalizedError {
             return "대상을 찾을 수 없습니다."
 
         case .conflict:
-            return "신청기간이 유효하지 않습니다."
-
-        case .tooManyRequest:
-            return "요청이 너무 많습니다."
+            return "다시 확인해주세요."
         }
     }
 }

--- a/Service/Sources/Domain/PostDomain/API/PostAPI.swift
+++ b/Service/Sources/Domain/PostDomain/API/PostAPI.swift
@@ -69,23 +69,10 @@ extension PostAPI: BitgouelAPI {
 
     public var errorMap: [Int: PostDomainError] {
         switch self {
-        case .writePost,
-             .updatePost,
-             .deletePost:
+        default:
             return [
-                400: .badRequest,
-                401: .unauthorized,
                 403: .forbidden,
-                404: .notFound,
-                429: .tooManyRequest
-            ]
-        case .queryPostList,
-             .queryPostDetail:
-            return [
-                400: .badRequest,
-                401: .unauthorized,
-                404: .notFound,
-                429: .tooManyRequest
+                404: .notFound
             ]
         }
     }

--- a/Service/Sources/Domain/PostDomain/Error/PostDomainError.swift
+++ b/Service/Sources/Domain/PostDomain/Error/PostDomainError.swift
@@ -1,9 +1,18 @@
 import Foundation
 
 public enum PostDomainError: Error {
-    case badRequest
-    case unauthorized
     case forbidden
     case notFound
-    case tooManyRequest
+}
+
+extension PostDomainError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .forbidden:
+            return "권한이 없습니다."
+
+        case .notFound:
+            return "대상을 찾을 수 없습니다."
+        }
+    }
 }

--- a/Service/Sources/Domain/UserDomain/API/UserAPI.swift
+++ b/Service/Sources/Domain/UserDomain/API/UserAPI.swift
@@ -49,19 +49,9 @@ extension UserAPI: BitgouelAPI {
 
     public var errorMap: [Int: UserDomainError] {
         switch self {
-        case .changePassword:
+        default:
             return [
-                400: .badRequest,
-                401: .unauthorized,
-                404: .notFound,
-                409: .conflict,
-                429: .tooManyRequest
-            ]
-        case .fetchMyInfo:
-            return [
-                400: .badRequest,
-                401: .unauthorized,
-                404: .notFound
+                401: .unauthorized
             ]
         }
     }

--- a/Service/Sources/Domain/UserDomain/Error/UserDomainError.swift
+++ b/Service/Sources/Domain/UserDomain/Error/UserDomainError.swift
@@ -1,9 +1,14 @@
 import Foundation
 
 public enum UserDomainError: Error {
-    case badRequest
     case unauthorized
-    case notFound
-    case conflict
-    case tooManyRequest
+}
+
+extension UserDomainError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "비밀번호가 일치하지 않습니다."
+        }
+    }
 }


### PR DESCRIPTION
## 💡 배경 및 개요
예외처리를 진행하던 도중 Description이 추가된 Domain이 있고 추가되지 않은 도메인이 있어서 맞추기 위해서 Description을 추가했어요.

Resolves: #329

## 📃 작업내용
- Auth, Club, Inquiry, Lecture, post, user Domain의 Error Description을 추가했어요.
- Certification, FAQ, Activity, Admin Domain의 Error Description을 수정했어요.
- 
## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
