### PR TITLE
🔀 :: [#329] 학생활동 예외처리

### DIFF
--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailView.swift
@@ -105,6 +105,10 @@ struct ActivityDetailView: View {
                 }
             ]
         )
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 
     @ViewBuilder
@@ -117,7 +121,6 @@ struct ActivityDetailView: View {
                     viewModel.updateIsPresentedInputActivityView(isPresented: true)
                 }
             )
-            .cornerRadius(8)
 
             Spacer()
 
@@ -128,7 +131,6 @@ struct ActivityDetailView: View {
                     viewModel.updateIsDelete(state: true)
                 }
             )
-            .cornerRadius(8)
         }
     }
 }

--- a/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailViewModel.swift
+++ b/App/Sources/Feature/ActivityDetailFeature/Sources/ActivityDetailViewModel.swift
@@ -36,12 +36,16 @@ final class ActivityDetailViewModel: BaseViewModel {
     @MainActor
     func onAppear() {
         authority = loadUserAuthorityUseCase()
+        isLoading = true
 
         Task {
             do {
                 activityDetail = try await fetchActivityDetailUseCase(activityID: activityID)
+
+                isLoading = false
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.activityDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
@@ -54,7 +58,8 @@ final class ActivityDetailViewModel: BaseViewModel {
 
                 success()
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.activityDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/ActivityListFeature/Source/ActivityListView.swift
+++ b/App/Sources/Feature/ActivityListFeature/Source/ActivityListView.swift
@@ -56,10 +56,7 @@ struct ActivityListView: View {
         }
         .bitgouelToast(
             text: viewModel.errorMessage,
-            isShowing: Binding(
-                get: { viewModel.isErrorOccurred },
-                set: { state in viewModel.updateIsErrorOccurred(state: state) }
-            )
+            isShowing: $viewModel.isErrorOccurred
         )
         .bitgouelBackButton(dismiss: dismiss)
         .padding(.horizontal, 28)

--- a/App/Sources/Feature/InputActivityFeature/Source/InputActivityView.swift
+++ b/App/Sources/Feature/InputActivityFeature/Source/InputActivityView.swift
@@ -57,5 +57,9 @@ struct InputActivityView: View {
                 viewModel.onAppear()
             }
         }
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 }

--- a/App/Sources/Feature/InputActivityFeature/Source/InputActivityViewModel.swift
+++ b/App/Sources/Feature/InputActivityFeature/Source/InputActivityViewModel.swift
@@ -53,7 +53,8 @@ final class InputActivityViewModel: BaseViewModel {
 
                 updateActivityDetail(entity: response)
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.activityDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
@@ -75,7 +76,8 @@ final class InputActivityViewModel: BaseViewModel {
 
                 success()
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.activityDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Utils/Extensions/Error+DomainErrorMessage.swift
+++ b/App/Sources/Utils/Extensions/Error+DomainErrorMessage.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Service
+
+extension Error {
+    var unknownErrorMessage: String {
+        "알 수 없는 오류가 발생했습니다."
+    }
+
+    func authDomainErrorMessage() -> String {
+        if let authDomainError = self as? AuthDomainError {
+            return authDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func activityDomainErrorMessage() -> String {
+        if let activityDomainError = self as? ActivityDomainError {
+            return activityDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+    
+    func adminDomainErrorMessage() -> String {
+        if let adminDomainError = self as? AdminDomainError {
+            return adminDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage}
+    }
+
+    func certificationDomainErrorMessage() -> String {
+        if let certificationDomainError = self as? CertificationDomainError {
+            return certificationDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func clubDomainErrorMessage() -> String {
+        if let clubDomainError = self as? ClubDomainError {
+            return clubDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func faqDomainErrorMessage() -> String {
+        if let faqDomainError = self as? FAQDomainError {
+            return faqDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func inquiryDomainErrorMessage() -> String {
+        if let inquiryDomainError = self as? InquiryDomainError {
+            return inquiryDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func lectureDomainErrorMessage() -> String {
+        if let lectureDomainError = self as? LectureDomainError {
+            return lectureDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func postDomainErrorMessage() -> String {
+        if let postDomainError = self as? PostDomainError {
+            return postDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func userDomainErrorMessage() -> String {
+        if let userDomainError = self as? UserDomainError {
+            return userDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+
+    func withdrawDomainErrorMessage() -> String {
+        if let withdrawDomainError = self as? WithdrawDomainError {
+            return withdrawDomainError.errorDescription ?? unknownErrorMessage
+        } else { return unknownErrorMessage }
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요
QA진행 중 학생활동 Feature들이 요청이 실패했을 때 예외처리가 진행되지 않아서 불편함을 겪었어요.

Resolves: #329

## 📃 작업내용
- 학생활동 목록
- 학생활동 상세
- 학생활동 입력(+수정)
페이지에 요청 실패 시 Toast메시지를 띄우도록 수정했어요!

## 🙋‍♂️ 리뷰노트
요청 실패시 catch 부분에 들어가는 코드들이 너무 중복되어서 줄여보려고 일단 각 Domain별로 다른 errorDescription을 띄우기 위해서 extension을 만들어 봤는데 실행은 잘 됩니다!! 읽어보시고 더 개선하면 좋을 점이 있다면 알려주세요!!

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?