### PR TITLE
🔀 :: [#329] 비밀번호 찾기, 변경 예외처리 추가

### DIFF
--- a/App/Sources/Feature/ChangePasswordFeature/Source/ChangePasswordView.swift
+++ b/App/Sources/Feature/ChangePasswordFeature/Source/ChangePasswordView.swift
@@ -74,10 +74,7 @@ struct ChangePasswordView: View {
         )
         .bitgouelToast(
             text: viewModel.errorMessage,
-            isShowing: Binding(
-                get: { viewModel.isShowingToast },
-                set: { newValue in viewModel.isShowingToast = newValue }
-            )
+            isShowing: $viewModel.isErrorOccurred
         )
         .onTapGesture {
             hideKeyboard()

--- a/App/Sources/Feature/ChangePasswordFeature/Source/ChangePasswordViewModel.swift
+++ b/App/Sources/Feature/ChangePasswordFeature/Source/ChangePasswordViewModel.swift
@@ -5,7 +5,6 @@ final class ChangePasswordViewModel: BaseViewModel {
     @Published var currentPassword: String = ""
     @Published var newPassword: String = ""
     @Published var checkNewPassword: String = ""
-    @Published var isShowingToast: Bool = false
     @Published var isPresentedSuccessView: Bool = false
 
     private let changePasswordUseCase: any ChangePasswordUseCase
@@ -22,7 +21,7 @@ final class ChangePasswordViewModel: BaseViewModel {
     func changePasswordButtonDidTap() {
         guard newPassword == checkNewPassword else {
             errorMessage = "비밀번호를 다시 입력해 주세요!"
-            return isShowingToast = true
+            return isErrorOccurred = true
         }
 
         Task {
@@ -33,9 +32,11 @@ final class ChangePasswordViewModel: BaseViewModel {
                         newPassword: newPassword
                     )
                 )
+
                 updateIsPresentedSuccessView(isPresented: true)
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.userDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
+++ b/App/Sources/Feature/FindPasswordFeature/Source/FindPasswordView.swift
@@ -34,12 +34,7 @@ struct FindPasswordView: View {
 
                 BitgouelTextField(
                     "이메일",
-                    text: Binding(
-                        get: { viewModel.email },
-                        set: { email in
-                            viewModel.updateEmail(email: email)
-                        }
-                    )
+                    text: $viewModel.email
                 )
                 .padding(.top, 32)
 
@@ -48,8 +43,9 @@ struct FindPasswordView: View {
                 BitgouelButton(
                     text: "다음으로",
                     action: {
-                        viewModel.updateIsPresentedSendEmailPage(isPresented: true)
-                        viewModel.nextToButtonDidTap()
+                        viewModel.nextToButtonDidTap {
+                            viewModel.updateIsPresentedSendEmailPage(isPresented: true)
+                        }
                     }
                 )
                 .disabled(viewModel.isEmailEmpty)
@@ -81,6 +77,10 @@ struct FindPasswordView: View {
                         viewModel.updateIsPresentedNewPasswordPage(isPresented: isPresented)
                     }
                 )
+            )
+            .bitgouelToast(
+                text: viewModel.errorMessage,
+                isShowing: $viewModel.isErrorOccurred
             )
         }
         .onTapGesture {


### PR DESCRIPTION
## 💡 배경 및 개요
QA진행 중 비밀번호 찾기, 변경 중 요청이 실패했을 때 예외처리가 진행되지 않아 불편함을 느끼는 문제가 발생했어요.

Resolves: #329 

## 📃 작업내용
- 비밀번호 찾기, 변경의 요청 실패시 Toast메시지를 띄우도록 추가했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?