### PR TITLE
🔀 :: [#329] 동아리 목록, 상세 예외처리

### DIFF
--- a/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailView.swift
+++ b/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailView.swift
@@ -95,6 +95,10 @@ struct ClubDetailView: View {
         .if(viewModel.authority != .admin) {
             $0.navigationBarBackButtonHidden()
         }
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
         .navigate(
             to: studentInfoFactory.makeView(
                 clubID: viewModel.clubID,

--- a/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailViewModel.swift
+++ b/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailViewModel.swift
@@ -49,7 +49,10 @@ final class ClubDetailViewModel: BaseViewModel {
 
                 isLoading = false
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.clubDomainErrorMessage()
+
+                isErrorOccurred = true
+                isLoading = false
             }
         }
     }

--- a/App/Sources/Feature/ClubListFeature/Source/ClubListView.swift
+++ b/App/Sources/Feature/ClubListFeature/Source/ClubListView.swift
@@ -111,6 +111,10 @@ struct ClubListView: View {
             ) {
                 $selection.wrappedValue = .home
             }
+            .bitgouelToast(
+                text: viewModel.errorMessage,
+                isShowing: $viewModel.isErrorOccurred
+            )
         }
     }
 }

--- a/App/Sources/Feature/ClubListFeature/Source/ClubListViewModel.swift
+++ b/App/Sources/Feature/ClubListFeature/Source/ClubListViewModel.swift
@@ -53,7 +53,8 @@ final class ClubListViewModel: BaseViewModel {
 
                 clubList = try await queryClubListUseCase(highSchool: selectedSchool.rawValue)
             } catch {
-                print(String(describing: error))
+                errorMessage = error.clubDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요
QA 진행 중 동아리 목록, 상세 조회 시 요청이 실패했을 때 예외처리가 진행되지 않아서 불편함을 겪었어요.

Resolves: #329 

## 📃 작업내용
- 동아리 목록 조회
- 동아리 상세 조회
요청이 실패했을 때 Toast메시지를 띄우도록 추가했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
