### PR TITLE
🔀 :: [#329] 문의사항 Feature 예외처리 추가

### DIFF
--- a/App/Sources/Feature/InputInquiryFeature/Source/InputInquiryView.swift
+++ b/App/Sources/Feature/InputInquiryFeature/Source/InputInquiryView.swift
@@ -57,9 +57,7 @@ struct InputInquiryView: View {
             Divider()
                 .padding(.bottom, 24)
 
-            BitgouelButton(
-                text: "문의사항 \(viewModel.state)"
-            ) {
+            BitgouelButton(text: "문의사항 \(viewModel.state)") {
                 viewModel.updateIsShowingAlert(isShowing: true)
             }
         }
@@ -91,6 +89,10 @@ struct InputInquiryView: View {
                     }
                 }
             ]
+        )
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
         )
     }
 }

--- a/App/Sources/Feature/InputInquiryFeature/Source/InputInquiryViewModel.swift
+++ b/App/Sources/Feature/InputInquiryFeature/Source/InputInquiryViewModel.swift
@@ -51,9 +51,11 @@ final class InputInquiryViewModel: BaseViewModel {
                 inquiryDetail = try await fetchInquiryDetailUseCase(inquiryID: inquiryID)
 
                 guard let inquiryDetail else { return }
+
                 updateQuestion(question: inquiryDetail)
             } catch {
-                print(String(describing: error))
+                errorMessage = error.inquiryDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
@@ -75,7 +77,8 @@ final class InputInquiryViewModel: BaseViewModel {
 
                 success()
             } catch {
-                print(String(describing: error))
+                errorMessage = error.inquiryDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/InquiryDetailFeature/Source/InquiryDetailView.swift
+++ b/App/Sources/Feature/InquiryDetailFeature/Source/InquiryDetailView.swift
@@ -144,7 +144,6 @@ struct InquiryDetailView: View {
                         viewModel.updateIsDeleteInquiry(isDelete: false)
                     }
                 ),
-
                 .init(
                     text: "삭제",
                     style: .error,
@@ -178,9 +177,14 @@ struct InquiryDetailView: View {
                     style: .default,
                     action: {
                         viewModel.updateIsPresentedWriteInquiryAnswerView(isPresented: true)
+                        viewModel.updateIsWriteInquiryAnswer(isWrite: false)
                     }
                 )
             ]
+        )
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
         )
     }
 
@@ -197,13 +201,15 @@ struct InquiryDetailView: View {
 
             Spacer()
 
-            BitgouelButton(
-                text: "문의 답변",
-                style: .primary,
-                action: {
-                    viewModel.updateIsWriteInquiryAnswer(isWrite: true)
-                }
-            )
+            if viewModel.inquiryDetail?.answerStatus == .unanswered {
+                BitgouelButton(
+                    text: "문의 답변",
+                    style: .primary,
+                    action: {
+                        viewModel.updateIsWriteInquiryAnswer(isWrite: true)
+                    }
+                )
+            }
         }
     }
 

--- a/App/Sources/Feature/InquiryDetailFeature/Source/InquiryDetailViewModel.swift
+++ b/App/Sources/Feature/InquiryDetailFeature/Source/InquiryDetailViewModel.swift
@@ -21,6 +21,7 @@ final class InquiryDetailViewModel: BaseViewModel {
         switch status {
         case .answered:
             return .bitgouel(.primary(.p5))
+
         case .unanswered:
             return .bitgouel(.error(.e5))
         }
@@ -64,7 +65,8 @@ final class InquiryDetailViewModel: BaseViewModel {
             do {
                 inquiryDetail = try await fetchInquiryDetailUseCase(inquiryID: inquiryID)
             } catch {
-                print(String(describing: error))
+                errorMessage = error.inquiryDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
@@ -76,13 +78,15 @@ final class InquiryDetailViewModel: BaseViewModel {
                 switch authority {
                 case .admin:
                     try await deleteInquiryByAdmin()
+
                 default:
                     try await deleteMyInquiry()
                 }
 
                 success()
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.inquiryDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
+++ b/App/Sources/Feature/InquiryListFeature/Source/InquiryListView.swift
@@ -21,6 +21,7 @@ struct InquiryListView: View {
         ZStack {
             if viewModel.isLoading {
                 ProgressView()
+                    .progressViewStyle(.circular)
             } else {
                 VStack(spacing: 4) {
                     if viewModel.authority == .admin {
@@ -35,10 +36,10 @@ struct InquiryListView: View {
                         }
                     }
 
-                    if viewModel.inquiryList.isEmpty {
-                        NoInfoView(text: "문의사항이 없어요")
-                    } else {
-                        ScrollView {
+                    ScrollView {
+                        if viewModel.inquiryList.isEmpty {
+                            NoInfoView(text: "문의사항이 없어요")
+                        } else {
                             VStack(spacing: 12) {
                                 ForEach(viewModel.inquiryList, id: \.inquiryID) { inquiry in
                                     InquiryListRow(
@@ -127,5 +128,9 @@ struct InquiryListView: View {
         .onAppear {
             viewModel.onAppear()
         }
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 }

--- a/App/Sources/Feature/InquiryListFeature/Source/InquiryListViewModel.swift
+++ b/App/Sources/Feature/InquiryListFeature/Source/InquiryListViewModel.swift
@@ -47,8 +47,10 @@ final class InquiryListViewModel: BaseViewModel {
         switch answer {
         case .all:
             answerStatus = nil
+
         case .answer:
             answerStatus = .answered
+
         case .unanswer:
             answerStatus = .unanswered
         }
@@ -63,32 +65,27 @@ final class InquiryListViewModel: BaseViewModel {
             do {
                 let inquiryInfo: [InquiryInfoEntity] = try await { () async throws -> [InquiryInfoEntity] in
                     switch authority {
-                    case .admin: return try await onAppearInquiryByAdmin()
-                    default: return try await onAppearMyInquiry()
+                    case .admin: 
+                        return try await onAppearInquiryByAdmin()
+
+                    default: 
+                        return try await onAppearMyInquiry()
                     }
                 }()
 
                 updateContent(entity: inquiryInfo)
                 isLoading = false
             } catch {
-                print(String(describing: error))
+                errorMessage = error.inquiryDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
 
-    @MainActor
+    @MainActor 
     func updateKeyword(text: String) {
         keyword = text
-
-        Task {
-            do {
-                let response = try await onAppearInquiryByAdmin()
-
-                updateContent(entity: response)
-            } catch {
-                print(error.localizedDescription)
-            }
-        }
+        onAppear()
     }
 
     func updateContent(entity: [InquiryInfoEntity]) {
@@ -96,7 +93,10 @@ final class InquiryListViewModel: BaseViewModel {
     }
 
     func onAppearInquiryByAdmin() async throws -> [InquiryInfoEntity] {
-        return try await fetchInquiryByAdminUseCase(answerStatus: answerStatus?.rawValue ?? "", keyword: keyword)
+        return try await fetchInquiryByAdminUseCase(
+            answerStatus: answerStatus?.rawValue ?? "",
+            keyword: keyword
+        )
     }
 
     func onAppearMyInquiry() async throws -> [InquiryInfoEntity] {

--- a/App/Sources/Feature/WriteInquiryAnswerFeature/Source/WriteInquiryAnswerView.swift
+++ b/App/Sources/Feature/WriteInquiryAnswerFeature/Source/WriteInquiryAnswerView.swift
@@ -24,8 +24,8 @@ struct WriteInquiryAnswerView: View {
                         text: "답변 내용 작성(최대 500자)",
                         font: .text3
                     )
-                    .padding(.top, 8)
-                    .padding(.leading, 4)
+                    .padding(.top, 12)
+                    .padding(.leading, 8)
                     .foregroundColor(.bitgouel(.greyscale(.g7)))
                 }
             }
@@ -43,5 +43,9 @@ struct WriteInquiryAnswerView: View {
             }
         }
         .padding(.horizontal, 28)
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 }

--- a/App/Sources/Feature/WriteInquiryAnswerFeature/Source/WriteInquiryAnswerViewModel.swift
+++ b/App/Sources/Feature/WriteInquiryAnswerFeature/Source/WriteInquiryAnswerViewModel.swift
@@ -26,7 +26,8 @@ final class WriteInquiryAnswerViewModel: BaseViewModel {
 
                 success()
             } catch {
-                print(String(describing: error))
+                errorMessage = error.inquiryDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요
QA진행 중에 문의사항 조회, 상세 조회, 답변 추가, 삭제, 수정, 작성 요청이 실패했을 때 예외처리가 진행되지 않아 불편함을 느끼는 문제가 발생했어요.

Resolves: #329 

## 📃 작업내용
- 문의사항 작성
- 문의사항 리스트 조회
- 문의사항 상세 조회
- 문의사항 삭제, 수정
- 문의사항 답변
위 요청들이 실패했을 때 Toast메시지를 띄우도록 예외처리를 진행했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?