### PR TITLE
🔀 :: [#329] 강의 Feature 예외 처리

### DIFF
--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListView.swift
@@ -48,5 +48,9 @@ struct LectureApplicantListView: View {
             viewModel.onAppear()
         }
         .navigationTitle("강의 신청자 명단")
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 }

--- a/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
+++ b/App/Sources/Feature/LectureApplicantListFeature/Source/LectureApplicantListViewModel.swift
@@ -31,7 +31,8 @@ final class LectureApplicantListViewModel: BaseViewModel {
             do {
                 applicantList = try await fetchApplicantListUseCase(lectureID: lectureID)
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.lectureDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
@@ -41,7 +42,8 @@ final class LectureApplicantListViewModel: BaseViewModel {
             do {
                 try await modifyApplicantWhetherUseCase(lectureID: lectureID, studentID: selectedStudentID, isComplete: isComplete)
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.lectureDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/LectureDetailSettingFeature/Sources/LectureDetailSettingViewModel.swift
+++ b/App/Sources/Feature/LectureDetailSettingFeature/Sources/LectureDetailSettingViewModel.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Service
 import SwiftUI
 

--- a/App/Sources/Feature/LectureListDetailFeature/LectureListDetailView.swift
+++ b/App/Sources/Feature/LectureListDetailFeature/LectureListDetailView.swift
@@ -165,12 +165,7 @@ struct LectureListDetailView: View {
                 )
                 .bitgouelToast(
                     text: viewModel.errorMessage,
-                    isShowing: Binding(
-                        get: { viewModel.isErrorOccurred },
-                        set: { state in
-                            viewModel.updateIsErrorOccurred(state: state)
-                        }
-                    )
+                    isShowing: $viewModel.isErrorOccurred
                 )
             }
         }

--- a/App/Sources/Feature/LectureListDetailFeature/LectureListDetailViewModel.swift
+++ b/App/Sources/Feature/LectureListDetailFeature/LectureListDetailViewModel.swift
@@ -29,10 +29,6 @@ final class LectureListDetailViewModel: BaseViewModel {
         self.loadUserAuthorityUseCase = loadUserAuthorityUseCase
     }
 
-    func updateIsErrorOccurred(state: Bool) {
-        isErrorOccurred = state
-    }
-
     func updateIsPresentedLectureApplicantView(isPresented: Bool) {
         isPresentedLectureApplicantListView = isPresented
     }
@@ -40,7 +36,6 @@ final class LectureListDetailViewModel: BaseViewModel {
     @MainActor
     func onAppear() {
         isLoading = true
-
         userAuthority = loadUserAuthorityUseCase()
 
         Task {
@@ -49,7 +44,10 @@ final class LectureListDetailViewModel: BaseViewModel {
 
                 isLoading = false
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.lectureDomainErrorMessage()
+
+                isErrorOccurred = true
+                isLoading = false
             }
         }
     }
@@ -60,15 +58,10 @@ final class LectureListDetailViewModel: BaseViewModel {
             do {
                 try await applyLectureUseCase(lectureID: lectureID)
             } catch {
-                if let lectureDomainError = error as? LectureDomainError {
-                    errorMessage = lectureDomainError.errorDescription ?? "알 수 없는 오류가 발생했습니다."
-                } else {
-                    errorMessage = "알 수 없는 오류가 발생했습니다."
-                }
-                updateIsErrorOccurred(state: true)
-                isApply = false
+                errorMessage = error.lectureDomainErrorMessage()
 
-                print(error.localizedDescription)
+                isErrorOccurred = true
+                isApply = false
             }
         }
     }
@@ -78,7 +71,9 @@ final class LectureListDetailViewModel: BaseViewModel {
             do {
                 try await cancelLectureUseCase(lectureID: lectureID)
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.lectureDomainErrorMessage()
+
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/LectureListFeature/Source/LectureListView.swift
+++ b/App/Sources/Feature/LectureListFeature/Source/LectureListView.swift
@@ -130,6 +130,10 @@ struct LectureListView: View {
             ) {
                 $selection.wrappedValue = .home
             }
+            .bitgouelToast(
+                text: viewModel.errorMessage,
+                isShowing: $viewModel.isErrorOccurred
+            )
         }
         .onAppear {
             viewModel.onAppear()
@@ -185,21 +189,25 @@ struct LectureListView: View {
     @ViewBuilder
     func lectureTypeList() -> some View {
         ForEach(viewModel.lectureType, id: \.self) { lectureType in
-            HStack {
-                CheckButton(
-                    isSelected: Binding(
-                        get: { viewModel.selectedLectureType == lectureType.rawValue },
-                        set: { lecture in
-                            if lecture {
-                                viewModel.selectedLectureType = lectureType.rawValue
-                            } else {
-                                viewModel.selectedLectureType = ""
+            if lectureType != .etc {
+                HStack {
+                    CheckButton(
+                        isSelected: Binding(
+                            get: { viewModel.selectedLectureType == lectureType.rawValue },
+                            set: { lecture in
+                                if lecture {
+                                    viewModel.selectedLectureType = lectureType.rawValue
+                                } else {
+                                    viewModel.selectedLectureType = ""
+                                }
                             }
-                        }
+                        )
                     )
-                )
-
-                Text(lectureType.rawValue)
+                    
+                    Text(lectureType.rawValue)
+                }
+            } else {
+                EmptyView()
             }
         }
     }

--- a/App/Sources/Feature/LectureListFeature/Source/LectureListViewModel.swift
+++ b/App/Sources/Feature/LectureListFeature/Source/LectureListViewModel.swift
@@ -43,9 +43,6 @@ final class LectureListViewModel: BaseViewModel {
         case "기업산학연계직업체험프로그램":
             return type = .companyIndustryLinkingJobExperienceProgram
 
-        case "기타":
-            return type = .etc
-
         default:
             return type = nil
         }
@@ -84,7 +81,8 @@ final class LectureListViewModel: BaseViewModel {
                     updateContent(entity: response)
                     isLoading = false
                 } catch {
-                    print(String(describing: error))
+                    errorMessage = error.lectureDomainErrorMessage()
+                    isErrorOccurred = true
                 }
             }
         }

--- a/App/Sources/Feature/OpenedLectureFeature/Sources/OpenedLectureView.swift
+++ b/App/Sources/Feature/OpenedLectureFeature/Sources/OpenedLectureView.swift
@@ -42,10 +42,7 @@ struct OpenedLectureView: View {
         }
         .bitgouelToast(
             text: viewModel.errorMessage,
-            isShowing: Binding(
-                get: { viewModel.isErrorOccurred },
-                set: { state in viewModel.updateIsErrorOccurred(state: state) }
-            )
+            isShowing: $viewModel.isErrorOccurred
         )
         .fullScreenCover(
             isPresented: Binding(

--- a/App/Sources/Feature/OpenedLectureFeature/Sources/OpenedLectureViewModel.swift
+++ b/App/Sources/Feature/OpenedLectureFeature/Sources/OpenedLectureViewModel.swift
@@ -37,10 +37,6 @@ final class OpenedLectureViewModel: BaseViewModel {
         lectureText = text
     }
 
-    func updateIsErrorOccurred(state: Bool) {
-        isErrorOccurred = state
-    }
-
     func updateOpenLectureInfo(detailInfo: OpenedLectureModel) {
         openLectureInfo = .init(
             semester: detailInfo.semester,
@@ -55,7 +51,6 @@ final class OpenedLectureViewModel: BaseViewModel {
             credit: detailInfo.credit,
             maxRegisteredUser: detailInfo.maxRegisteredUser
         )
-        print(openLectureInfo)
     }
 
     @MainActor
@@ -88,14 +83,8 @@ final class OpenedLectureViewModel: BaseViewModel {
 
                 success()
             } catch {
-                if let lectureDomainError = error as? LectureDomainError {
-                    errorMessage = lectureDomainError.errorDescription ?? "알 수 없는 오류가 발생했습니다."
-                } else {
-                    errorMessage = "알 수 없는 오류가 발생했습니다."
-                }
-                updateIsErrorOccurred(state: true)
-
-                print(error.localizedDescription)
+                errorMessage = error.lectureDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요
QA진행 중 강의 목록 조회, 강의 상세 조회, 신청자 명단 조회, 개설 요청 실패 시 아무런 조치가 없어서 사용 중 불편함을 느꼈어요.

Resolves: #329 

## 📃 작업내용
- 강의 리스트 조회
- 강의 상세정보 조회
- 강의 수강 신청
- 강의 수강 신청 취소
- 강의 이수 중인 학생 전체 조회
- 강의 이수 여부 수정
기능의 요청이 실패 할 때 Toast메시지가 띄워지도록 추가했어요.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?