### PR TITLE
🔀 :: [#329] 공지사항 Feature 예외 처리

### DIFF
--- a/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeView.swift
+++ b/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeView.swift
@@ -16,30 +16,35 @@ struct InputNoticeView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            InputFormView(
-                epic: "공지사항",
-                state: viewModel.state,
-                settingButtonAction: {
-                    viewModel.updateIsPresentedNoticeSettingAppend(isPresented: true)
-                },
-                finalButtonAction: {
-                    viewModel.applyButtonDidTap {
-                        dismiss()
-                    }
-                },
-                title: Binding(
-                    get: { viewModel.noticeTitle },
-                    set: { title in viewModel.updateNoticeTitle(title: title) }
-                ),
-                text: Binding(
-                    get: { viewModel.noticeContent },
-                    set: { content in viewModel.updateNoticeContent(content: content) }
+            if viewModel.isLoading {
+                ProgressView()
+                    .progressViewStyle(.circular)
+            } else {
+                InputFormView(
+                    epic: "공지사항",
+                    state: viewModel.state,
+                    settingButtonAction: {
+                        viewModel.updateIsPresentedNoticeSettingAppend(isPresented: true)
+                    },
+                    finalButtonAction: {
+                        viewModel.applyButtonDidTap {
+                            dismiss()
+                        }
+                    },
+                    title: Binding(
+                        get: { viewModel.noticeTitle },
+                        set: { title in viewModel.updateNoticeTitle(title: title) }
+                    ),
+                    text: Binding(
+                        get: { viewModel.noticeContent },
+                        set: { content in viewModel.updateNoticeContent(content: content) }
+                    )
                 )
-            )
-            .onAppear {
-                if viewModel.state == "수정" {
-                    viewModel.onAppear()
-                }
+            }
+        }
+        .onAppear {
+            if viewModel.state == "수정" {
+                viewModel.onAppear()
             }
         }
         .onTapGesture {
@@ -59,5 +64,9 @@ struct InputNoticeView: View {
                 }.eraseToAnyView()
             }
         }
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 }

--- a/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeViewModel.swift
+++ b/App/Sources/Feature/InputNoticeFeature/Source/InputNoticeViewModel.swift
@@ -39,20 +39,29 @@ final class InputNoticeViewModel: BaseViewModel {
         noticeLinks = links
     }
 
+    func updateNoticeDetail(noticeDetail: PostDetailEntity) {
+        noticeTitle = noticeDetail.title
+        noticeContent = noticeDetail.content
+        noticeLinks = noticeDetail.links
+    }
+
     func updateIsPresentedNoticeSettingAppend(isPresented: Bool) {
         isPresentedNoticeDetailSettingAppend = isPresented
     }
 
     @MainActor
     func onAppear() {
+        isLoading = true
+
         Task {
             do {
                 let noticeDetail = try await queryPostDetailUseCase(postID: noticeID)
-                updateNoticeTitle(title: noticeDetail.title)
-                updateNoticeContent(content: noticeDetail.content)
-                updateNoticeLinks(links: noticeDetail.links)
+
+                updateNoticeDetail(noticeDetail: noticeDetail)
+                isLoading = false
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.postDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
@@ -72,7 +81,8 @@ final class InputNoticeViewModel: BaseViewModel {
 
                 success()
             } catch {
-                print(String(describing: error))
+                errorMessage = error.postDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/NoticeDetailFeature/Source/NoticeDetailView.swift
+++ b/App/Sources/Feature/NoticeDetailFeature/Source/NoticeDetailView.swift
@@ -15,24 +15,31 @@ struct NoticeDetailView: View {
     }
 
     var body: some View {
-        DetailView(
-            title: viewModel.noticeDetail?.title ?? "",
-            content: viewModel.noticeDetail?.content ?? "",
-            links: viewModel.noticeDetail?.links ?? [""],
-            writtenBy: viewModel.noticeDetail?.writtenBy ?? false,
-            deleteAction: {
-                viewModel.deleteNotice {
-                    dismiss()
-                }
-            },
-            editAction: {
-                viewModel.updateIsPresentedInputNoticeView(isPresented: true)
-            },
-            isDelete: Binding(
-                get: { viewModel.isDeleteNotice },
-                set: { isDelete in viewModel.updateIsDeleteNotice(isDelete: isDelete) }
-            )
-        )
+        VStack {
+            if viewModel.isLoading {
+                ProgressView()
+                    .progressViewStyle(.circular)
+            } else {
+                DetailView(
+                    title: viewModel.noticeDetail?.title ?? "",
+                    content: viewModel.noticeDetail?.content ?? "",
+                    links: viewModel.noticeDetail?.links ?? [""],
+                    writtenBy: viewModel.noticeDetail?.writtenBy ?? false,
+                    deleteAction: {
+                        viewModel.deleteNotice {
+                            dismiss()
+                        }
+                    },
+                    editAction: {
+                        viewModel.updateIsPresentedInputNoticeView(isPresented: true)
+                    },
+                    isDelete: Binding(
+                        get: { viewModel.isDeleteNotice },
+                        set: { isDelete in viewModel.updateIsDeleteNotice(isDelete: isDelete) }
+                    )
+                )
+            }
+        }
         .navigate(
             to: inputNoticeFactory.makeView(
                 state: "수정",
@@ -48,5 +55,9 @@ struct NoticeDetailView: View {
         .onAppear {
             viewModel.onAppear()
         }
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 }

--- a/App/Sources/Feature/NoticeDetailFeature/Source/NoticeDetailViewModel.swift
+++ b/App/Sources/Feature/NoticeDetailFeature/Source/NoticeDetailViewModel.swift
@@ -30,11 +30,16 @@ final class NoticeDetailViewModel: BaseViewModel {
 
     @MainActor
     func onAppear() {
+        isLoading = true
+
         Task {
             do {
                 noticeDetail = try await queryPostDetailUseCase(postID: noticeID)
+
+                isLoading = false
             } catch {
-                print(String(describing: error))
+                errorMessage = error.postDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
@@ -47,7 +52,8 @@ final class NoticeDetailViewModel: BaseViewModel {
 
                 success()
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.postDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListView.swift
@@ -23,25 +23,30 @@ struct NoticeListView: View {
 
     var body: some View {
         VStack {
-            if let noticeInfo = viewModel.noticeContent {
-                if noticeInfo.content.isEmpty {
-                    NoInfoView(text: "공지사항이 없어요")
-                } else {
-                    ScrollView {
-                        LazyVStack(spacing: 0) {
-                            ForEach(noticeInfo.content, id: \.postID) { notice in
-                                ListRow(
-                                    id: notice.postID,
-                                    title: notice.title,
-                                    modifiedAt: notice.modifiedAt
-                                        .toDateCustomFormat(format: "yyyy-MM-dd'T'HH:mm:ss.SSS")
-                                )
-                                .onTapGesture {
-                                    viewModel.noticeID = notice.postID
-                                    viewModel.updateIsPresentedNoticeDetailView(isPresented: true)
+            if viewModel.isLoading {
+                ProgressView()
+                    .progressViewStyle(.circular)
+            } else {
+                if let noticeInfo = viewModel.noticeContent {
+                    if noticeInfo.content.isEmpty {
+                        NoInfoView(text: "공지사항이 없어요")
+                    } else {
+                        ScrollView {
+                            LazyVStack(spacing: 0) {
+                                ForEach(noticeInfo.content, id: \.postID) { notice in
+                                    ListRow(
+                                        id: notice.postID,
+                                        title: notice.title,
+                                        modifiedAt: notice.modifiedAt
+                                            .toDateCustomFormat(format: "yyyy-MM-dd'T'HH:mm:ss.SSS")
+                                    )
+                                    .onTapGesture {
+                                        viewModel.noticeID = notice.postID
+                                        viewModel.updateIsPresentedNoticeDetailView(isPresented: true)
+                                    }
+                                    
+                                    Divider()
                                 }
-
-                                Divider()
                             }
                         }
                     }
@@ -113,5 +118,9 @@ struct NoticeListView: View {
         .refreshable {
             viewModel.onAppear()
         }
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 }

--- a/App/Sources/Feature/NoticeListFeature/Source/NoticeListViewModel.swift
+++ b/App/Sources/Feature/NoticeListFeature/Source/NoticeListViewModel.swift
@@ -45,12 +45,16 @@ final class NoticeListViewModel: BaseViewModel {
     @MainActor
     func onAppear() {
         authority = loadUserAuthorityUseCase()
+        isLoading = true
 
         Task {
             do {
                 noticeContent = try await queryPostListUseCase(postType: .notice)
+
+                isLoading = false
             } catch {
-                print(String(describing: error))
+                errorMessage = error.postDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요
QA진행 중 공지사항 리스트 조회, 상세 조회, 수정, 삭제, 작성 요청이 실패했을 때의 조치가 취해지지 않아 불편함을 느꼈어요.

Resolves: #329 

## 📃 작업내용
- 공지사항 리스트 조회
- 공지사항 상세 조회
- 공지사항 수정, 삭제, 작성
위 요청들이 실패했을 때 Toast메시지가 띄워지도록 추가했어요

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?