### PR TITLE
🔀 :: [#329] 로그인, 마이페이지, 자격증, 학생정보 페이지 예외처리

### DIFF
--- a/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailViewModel.swift
+++ b/App/Sources/Feature/ClubDetailFaeture/Source/ClubDetailViewModel.swift
@@ -52,7 +52,6 @@ final class ClubDetailViewModel: BaseViewModel {
                 errorMessage = error.clubDomainErrorMessage()
 
                 isErrorOccurred = true
-                isLoading = false
             }
         }
     }

--- a/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationView.swift
+++ b/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationView.swift
@@ -72,6 +72,10 @@ struct InputCertificationView: View {
                     }
                 }
             }
+            .bitgouelToast(
+                text: viewModel.errorMessage,
+                isShowing: $viewModel.isErrorOccurred
+            )
         }
     }
 }

--- a/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationViewModel.swift
+++ b/App/Sources/Feature/InputCertificationFeature/Source/InputCertificationViewModel.swift
@@ -47,7 +47,8 @@ final class InputCertificationViewModel: BaseViewModel {
 
                 success()
             } catch {
-                print(error.localizedDescription)
+                errorMessage = "error.certificationDomainErrorMessage()"
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/LoginFeature/Sources/LoginView.swift
+++ b/App/Sources/Feature/LoginFeature/Sources/LoginView.swift
@@ -126,6 +126,10 @@ struct LoginView: View {
                 sceneState.sceneFlow = .findPassword
                 tabbarHidden.wrappedValue = newValue
             }
+            .bitgouelToast(
+                text: viewModel.errorMessage,
+                isShowing: $viewModel.isErrorOccurred
+            )
         }
         .onTapGesture {
             hideKeyboard()

--- a/App/Sources/Feature/LoginFeature/Sources/LoginViewModel.swift
+++ b/App/Sources/Feature/LoginFeature/Sources/LoginViewModel.swift
@@ -92,17 +92,20 @@ final class LoginViewModel: BaseViewModel {
 
     @MainActor
     func login() {
-        guard checkEmail(email) && checkPassword(password) else { return }
+        guard checkEmail(email) && checkPassword(password) else {
+            errorMessage = "이메일, 비밀번호를 제대로 작성했는지 확인해주세요."
+            return isErrorOccurred = true
+        }
 
         Task {
             do {
                 let userLoginInfo = try await self.loginUseCase(req: LoginRequestDTO(email: email, password: password))
+
                 saveUserAuthority(authority: userLoginInfo.authority)
                 isSuccessSignin = true
-                print("로그인 성공 \(userLoginInfo.authority)")
             } catch {
+                errorMessage = error.authDomainErrorMessage()
                 isErrorOccurred = true
-                print("로그인 실패: \(error)")
             }
         }
     }

--- a/App/Sources/Feature/MyPageFeature/Source/MyPageView.swift
+++ b/App/Sources/Feature/MyPageFeature/Source/MyPageView.swift
@@ -25,124 +25,128 @@ struct MyPageView: View {
         NavigationView {
             VStack(alignment: .leading, spacing: 40) {
                 if let myInfo = viewModel.myInfo {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 4) {
-                                BitgouelText(
-                                    text: myInfo.name,
-                                    font: .title2
-                                )
-
-                                BitgouelText(
-                                    text: myInfo.authority.display(),
-                                    font: .text1
-                                )
-                                .foregroundColor(.bitgouel(.greyscale(.g7)))
+                    ScrollView {
+                        VStack(alignment: .leading) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack(spacing: 4) {
+                                        BitgouelText(
+                                            text: myInfo.name,
+                                            font: .title2
+                                        )
+                                        
+                                        BitgouelText(
+                                            text: myInfo.authority.display(),
+                                            font: .text1
+                                        )
+                                        .foregroundColor(.bitgouel(.greyscale(.g7)))
+                                    }
+                                    
+                                    if viewModel.authority != .admin {
+                                        HStack(spacing: 4) {
+                                            BitgouelText(
+                                                text: viewModel.userOrganization,
+                                                font: .text1
+                                            )
+                                            
+                                            BitgouelText(
+                                                text: "소속",
+                                                font: .text1
+                                            )
+                                            .foregroundColor(.bitgouel(.greyscale(.g7)))
+                                        }
+                                        
+                                        LazyVStack(alignment: .leading, spacing: 4) {
+                                            ForEach(viewModel.userInfo, id: \.self) { info in
+                                                BitgouelText(
+                                                    text: info,
+                                                    font: .text3
+                                                )
+                                                .foregroundColor(.bitgouel(.greyscale(.g4)))
+                                            }
+                                        }
+                                    }
+                                }
+                                
+                                Spacer()
                             }
-
-                            if viewModel.authority != .admin {
-                                HStack(spacing: 4) {
+                            .padding(.top, 32)
+                            
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
                                     BitgouelText(
-                                        text: viewModel.userOrganization,
+                                        text: "계정 정보",
                                         font: .text1
                                     )
-
+                                    
                                     BitgouelText(
-                                        text: "소속",
-                                        font: .text1
+                                        text: myInfo.email,
+                                        font: .text3
+                                    )
+                                    .foregroundColor(.bitgouel(.greyscale(.g7)))
+                                    
+                                    BitgouelText(
+                                        text: myInfo.phoneNumber,
+                                        font: .text3
                                     )
                                     .foregroundColor(.bitgouel(.greyscale(.g7)))
                                 }
-
-                                LazyVStack(alignment: .leading, spacing: 4) {
-                                    ForEach(viewModel.userInfo, id: \.self) { info in
+                                
+                                Spacer()
+                            }
+                            
+                            if viewModel.authority == .admin {
+                                adminUserListButton()
+                            }
+                            
+                            HStack {
+                                VStack(alignment: .leading, spacing: 21) {
+                                    BitgouelText(
+                                        text: "계정 설정",
+                                        font: .text1
+                                    )
+                                    
+                                    Button {
+                                        viewModel.updateIsPresentedChangePasswordView(isPresented: true)
+                                    } label: {
                                         BitgouelText(
-                                            text: info,
+                                            text: "비밀번호 변경",
                                             font: .text3
                                         )
-                                        .foregroundColor(.bitgouel(.greyscale(.g4)))
+                                    }
+                                    .padding(.top, 19)
+                                    
+                                    Divider()
+                                    
+                                    Button {
+                                        viewModel.updateIsShowingLogoutAlert(isShowing: true)
+                                    } label: {
+                                        BitgouelText(
+                                            text: "로그아웃",
+                                            font: .text3
+                                        )
+                                    }
+                                    
+                                    Divider()
+                                    
+                                    Button {
+                                        viewModel.updateIsShowingWithdrawAlert(isShowing: true)
+                                    } label: {
+                                        BitgouelText(
+                                            text: "회원 탈퇴",
+                                            font: .text3
+                                        )
+                                        .foregroundColor(.bitgouel(.error(.e5)))
                                     }
                                 }
+                                
+                                Spacer()
                             }
+                            .padding(.top, 60)
+                            
+                            Spacer()
                         }
-
-                        Spacer()
                     }
-                    .padding(.top, 32)
-
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            BitgouelText(
-                                text: "계정 정보",
-                                font: .text1
-                            )
-
-                            BitgouelText(
-                                text: myInfo.email,
-                                font: .text3
-                            )
-                            .foregroundColor(.bitgouel(.greyscale(.g7)))
-
-                            BitgouelText(
-                                text: myInfo.phoneNumber,
-                                font: .text3
-                            )
-                            .foregroundColor(.bitgouel(.greyscale(.g7)))
-                        }
-
-                        Spacer()
-                    }
-
-                    if viewModel.authority == .admin {
-                        adminUserListButton()
-                    }
-
-                    HStack {
-                        VStack(alignment: .leading, spacing: 21) {
-                            BitgouelText(
-                                text: "계정 설정",
-                                font: .text1
-                            )
-
-                            Button {
-                                viewModel.updateIsPresentedChangePasswordView(isPresented: true)
-                            } label: {
-                                BitgouelText(
-                                    text: "비밀번호 변경",
-                                    font: .text3
-                                )
-                            }
-                            .padding(.top, 19)
-
-                            Divider()
-
-                            Button {
-                                viewModel.updateIsShowingLogoutAlert(isShowing: true)
-                            } label: {
-                                BitgouelText(
-                                    text: "로그아웃",
-                                    font: .text3
-                                )
-                            }
-
-                            Divider()
-
-                            Button {
-                                viewModel.updateIsShowingWithdrawAlert(isShowing: true)
-                            } label: {
-                                BitgouelText(
-                                    text: "회원 탈퇴",
-                                    font: .text3
-                                )
-                                .foregroundColor(.bitgouel(.error(.e5)))
-                            }
-                        }
-
-                        Spacer()
-                    }
-                    .padding(.top, 60)
-
-                    Spacer()
                 }
             }
             .onAppear {
@@ -194,8 +198,9 @@ struct MyPageView: View {
                         text: "탈퇴",
                         style: .error
                     ) {
-                        viewModel.withdraw()
-                        sceneState.sceneFlow = .login
+                        viewModel.withdraw {
+                            sceneState.sceneFlow = .login
+                        }
                     }
                 ]
             )
@@ -229,10 +234,15 @@ struct MyPageView: View {
                         text: "로그아웃",
                         style: .error
                     ) {
-                        viewModel.logout()
-                        sceneState.sceneFlow = .login
+                        viewModel.logout {
+                            sceneState.sceneFlow = .login
+                        }
                     }
                 ]
+            )
+            .bitgouelToast(
+                text: viewModel.errorMessage,
+                isShowing: $viewModel.isErrorOccurred
             )
         }
     }

--- a/App/Sources/Feature/MyPageFeature/Source/MyPageViewModel.swift
+++ b/App/Sources/Feature/MyPageFeature/Source/MyPageViewModel.swift
@@ -72,28 +72,31 @@ final class MyPageViewModel: BaseViewModel {
 
                     updateOrganization(organization: myInfo?.organization ?? "")
                 } catch {
-                    print(String(describing: error))
+                    errorMessage = error.userDomainErrorMessage()
+                    isErrorOccurred = true
                 }
             }
         }
     }
 
-    func logout() {
+    func logout(_ success: () -> Void) {
         Task {
             do {
                 try await logoutUseCase()
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.authDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }
 
-    func withdraw() {
+    func withdraw(_ success: () -> Void) {
         Task {
             do {
                 try await withdrawalUseCase()
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.authDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/App/Sources/Feature/StudentInfoFeature/Source/StudentInfoView.swift
+++ b/App/Sources/Feature/StudentInfoFeature/Source/StudentInfoView.swift
@@ -18,107 +18,112 @@ struct StudentInfoView: View {
 
     var body: some View {
         VStack(spacing: 24) {
-            if let studentInfo = viewModel.studentInfo {
-                VStack(alignment: .leading, spacing: 4) {
-                    BitgouelText(
-                        text: studentInfo.name,
-                        font: .title2
-                    )
-
-                    HStack {
+            if viewModel.isLoading {
+                ProgressView()
+                    .progressViewStyle(.circular)
+            } else {
+                if let studentInfo = viewModel.studentInfo {
+                    VStack(alignment: .leading, spacing: 4) {
                         BitgouelText(
-                            text: "총 학점",
-                            font: .text3
+                            text: studentInfo.name,
+                            font: .title2
                         )
-
-                        Spacer()
-
-                        BitgouelText(
-                            text: "\(studentInfo.credit)",
-                            font: .text3
-                        )
-                    }
-                    .foregroundColor(.bitgouel(.primary(.p5)))
-
-                    HStack {
-                        BitgouelText(
-                            text: "이메일",
-                            font: .caption
-                        )
-
-                        Spacer()
-
-                        BitgouelText(
-                            text: studentInfo.email,
-                            font: .text2
-                        )
-                    }
-                    .foregroundColor(.bitgouel(.greyscale(.g4)))
-
-                    HStack {
-                        BitgouelText(
-                            text: "전화번호",
-                            font: .caption
-                        )
-
-                        Spacer()
-
-                        BitgouelText(
-                            text: studentInfo.phoneNumber.withHypen,
-                            font: .caption
-                        )
-                    }
-                }
-                .padding(.top, 24)
-            }
-
-            Divider()
-
-            HStack {
-                BitgouelText(
-                    text: "자격증",
-                    font: .title3
-                )
-
-                Spacer()
-
-                Button {
-                    viewModel.updateIsPresentedInputCertificationView(isPresented: true)
-                } label: {
-                    BitgouelAsset.Icons.add.swiftUIImage
-                }
-            }
-
-            ScrollView(showsIndicators: false) {
-                LazyVStack(spacing: 0) {
-                    ForEach(viewModel.certificationList, id: \.certificationID) { certification in
-                        CertificationListRow(
-                            id: certification.certificationID,
-                            title: certification.name,
-                            acquisitionDate: certification.acquisitionDate
-                        ) {
-                            viewModel.updateEpic(epic: "수정")
-                            viewModel.selectedCertification(
-                                certificationID: certification.certificationID,
-                                certificationName: certification.name,
-                                acquisitionDate: certification.acquisitionDate
+                        
+                        HStack {
+                            BitgouelText(
+                                text: "총 학점",
+                                font: .text3
                             )
-                            viewModel.updateIsPresentedInputCertificationView(isPresented: true)
+                            
+                            Spacer()
+                            
+                            BitgouelText(
+                                text: "\(studentInfo.credit)",
+                                font: .text3
+                            )
                         }
-
-                        Divider()
+                        .foregroundColor(.bitgouel(.primary(.p5)))
+                        
+                        HStack {
+                            BitgouelText(
+                                text: "이메일",
+                                font: .caption
+                            )
+                            
+                            Spacer()
+                            
+                            BitgouelText(
+                                text: studentInfo.email,
+                                font: .text2
+                            )
+                        }
+                        .foregroundColor(.bitgouel(.greyscale(.g4)))
+                        
+                        HStack {
+                            BitgouelText(
+                                text: "전화번호",
+                                font: .caption
+                            )
+                            
+                            Spacer()
+                            
+                            BitgouelText(
+                                text: studentInfo.phoneNumber.withHypen,
+                                font: .caption
+                            )
+                        }
+                    }
+                    .padding(.top, 24)
+                }
+                
+                Divider()
+                
+                HStack {
+                    BitgouelText(
+                        text: "자격증",
+                        font: .title3
+                    )
+                    
+                    Spacer()
+                    
+                    Button {
+                        viewModel.updateIsPresentedInputCertificationView(isPresented: true)
+                    } label: {
+                        BitgouelAsset.Icons.add.swiftUIImage
                     }
                 }
-
-                switch viewModel.authority {
-                case .admin,
-                     .teacher,
-                     .student:
-                    appliedLectureList()
-                        .padding(.top, 24)
-
-                default:
-                    EmptyView()
+                
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(viewModel.certificationList, id: \.certificationID) { certification in
+                            CertificationListRow(
+                                id: certification.certificationID,
+                                title: certification.name,
+                                acquisitionDate: certification.acquisitionDate
+                            ) {
+                                viewModel.updateEpic(epic: "수정")
+                                viewModel.selectedCertification(
+                                    certificationID: certification.certificationID,
+                                    certificationName: certification.name,
+                                    acquisitionDate: certification.acquisitionDate
+                                )
+                                viewModel.updateIsPresentedInputCertificationView(isPresented: true)
+                            }
+                            
+                            Divider()
+                        }
+                    }
+                    
+                    switch viewModel.authority {
+                    case .admin,
+                            .teacher,
+                            .student:
+                        appliedLectureList()
+                            .padding(.top, 24)
+                        
+                    default:
+                        EmptyView()
+                    }
                 }
             }
         }
@@ -161,6 +166,10 @@ struct StudentInfoView: View {
         .onAppear {
             viewModel.onAppear()
         }
+        .bitgouelToast(
+            text: viewModel.errorMessage,
+            isShowing: $viewModel.isErrorOccurred
+        )
     }
 
     @ViewBuilder

--- a/App/Sources/Feature/StudentInfoFeature/Source/StudentInfoViewModel.swift
+++ b/App/Sources/Feature/StudentInfoFeature/Source/StudentInfoViewModel.swift
@@ -61,6 +61,7 @@ final class StudentInfoViewModel: BaseViewModel {
     @MainActor
     func onAppear() {
         authority = loadUserAuthorityUseCase()
+        isLoading = true
 
         Task {
             do {
@@ -79,8 +80,11 @@ final class StudentInfoViewModel: BaseViewModel {
                 default:
                     try await updateCertificationListByTeacher()
                 }
+
+                isLoading = false
             } catch {
-                print(error.localizedDescription)
+                errorMessage = error.certificationDomainErrorMessage()
+                isErrorOccurred = true
             }
         }
     }

--- a/Service/Sources/Base/DataSource/BaseRemoteDataSource.swift
+++ b/Service/Sources/Base/DataSource/BaseRemoteDataSource.swift
@@ -16,7 +16,7 @@ open class BaseRemoteDataSource<API: BitgouelAPI> {
         #if DEV || STAGE
         self.provider = provider ?? MoyaProvider(plugins: [JwtPlugin(keychain: keychain), MoyaLoggingPlugin()])
         #else
-        self.provider = provider ?? MoyaProvider(plugins: [JwtPlugin(keychain: keychain)])
+        self.provider = provider ?? MoyaProvider(plugins: [JwtPlugin(keychain: keychain), MoyaLoggingPlugin()])
         #endif
     }
 


### PR DESCRIPTION
## 💡 배경 및 개요
QA 진행 중 로그인, 자격증 조회, 작성 수정, 강의 신청내역 조회, 로그아웃, 회원탈퇴 요청 실패시 아무런 조치도 취해지지 않아 불편함을 느꼈어요.

Resolves: #329 

## 📃 작업내용
- 로그아웃
- 회원탈퇴
- 마이페이지
- 강의 신청 내역 조회
- 자격증 리스트 조회, 작성, 수정
- 로그인
위 요청들이 실패했을 때 Toast메시지가 나오도록 추가했어요.

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?